### PR TITLE
Add User Routes and Shared Interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # tinder-api
 
-`tinder-api` is an unofficial library to interact with Tinder's API. Designed to work seamlessly with both Node.js and Deno, it simplifies the process of performing actions such as liking, disliking, and retrieving profiles, as well as
-accessing search results.
+`tinder-api` is an unofficial library to interact with Tinder's API. Designed to work seamlessly with both Node.js and Deno, it simplifies
+the process of performing actions such as liking, disliking, and retrieving profiles, as well as accessing search results.
 
 ## Features
 
--   Perform searches for profiles.
--   Like or dislike profiles.
--   Retrieve authenticated user profile information.
--   Designed for flexibility and easy integration.
+- Perform searches for profiles.
+- Like or dislike profiles.
+- Retrieve authenticated user profile information.
+- Designed for flexibility and easy integration.
 
 ## Installation
 
@@ -113,13 +113,15 @@ const likeResponse = await api.like({
 
 ## API Methods
 
-| Method                                                                                       | Description                                                                                          |
-| -------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | --- |
-| `search(params?: TinderSearchParams): Promise<TinderResponse<TinderSearchResponse>>`         | Search for profiles.                                                                                 |
-| `like(params: TinderLikeParams): Promise<TinderResponse<TinderLikeResponse>>`                | Like a profile.                                                                                      |
-| `dislike(params: TinderDislikeParams): Promise<TinderResponse<TinderDislikeResponse>>`       | Dislike a profile.                                                                                   |
-| `profile(params?: TinderProfileParams): Promise<TinderResponse<TinderProfileResponse>>`      | Retrieve authenticated user profile.                                                                 |     |
-| `setLocation(params: TinderLocationParams): Promise<TinderResponse<TinderLocationResponse>>` | Sets the user's location using latitude and longitude. Note: Can only be used once every 10 minutes. |
+| Method                                                                                             | Description                                                                                          |
+| -------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `search(params?: TinderSearchParams): Promise<TinderResponse<TinderSearchResponse>>`               | Search for profiles.                                                                                 |
+| `like(params: TinderLikeParams): Promise<TinderResponse<TinderLikeResponse>>`                      | Like a profile.                                                                                      |
+| `dislike(params: TinderDislikeParams): Promise<TinderResponse<TinderDislikeResponse>>`             | Dislike a profile.                                                                                   |
+| `profile(params?: TinderProfileParams): Promise<TinderResponse<TinderProfileResponse>>`            | Retrieve authenticated user profile.                                                                 |
+| `setLocation(params: TinderLocationParams): Promise<TinderResponse<TinderLocationResponse>>`       | Sets the user's location using latitude and longitude. Note: Can only be used once every 10 minutes. |
+| `editProfile(params: TinderEditProfileParams): Promise<TinderResponse<TinderEditProfileResponse>>` | Edit the authenticated user's profile. Note: plus_control options require Tinder Plus.               |
+| `getUser(params: TinderUserParams): Promise<TinderResponse<TinderUserResponse>>`                   | Get a user's profile by username.                                                                    |
 
 ## Interfaces
 
@@ -170,6 +172,24 @@ Parameters for setting user location.
 | `lat`    | `number` | Latitude coordinate for the location.  |
 | `lon`    | `number` | Longitude coordinate for the location. |
 
+### TinderEditProfileParams
+
+Parameters for editing user profile.
+
+| Property       | Type     | Description                                                                                                  |
+| -------------- | -------- | ------------------------------------------------------------------------------------------------------------ |
+| `user`         | `object` | User profile settings including distance_filter, age filters, bio, gender, etc. All properties are optional. |
+| `plus_control` | `object` | Optional Tinder Plus settings including hide_age, hide_distance, blend, hide_ads, and discoverable_party.    |
+
+### TinderUserParams
+
+Parameters for getting a user's profile.
+
+| Property   | Type     | Description                                  |
+| ---------- | -------- | -------------------------------------------- |
+| `username` | `string` | The username of the profile to retrieve.     |
+| `locale`   | `string` | Optional. The locale to use for the request. |
+
 ## Error Handling
 
 The library throws detailed errors if a request fails. Wrap your calls in `try-catch` to handle exceptions gracefully.
@@ -189,7 +209,8 @@ This project is licensed under the MIT License. See the [LICENSE](LICENSE) file 
 
 ## Contributing
 
-Contributions are welcome! If you encounter issues, have ideas for improvements, or want to contribute new features, feel free to open an issue or submit a pull request on the [GitHub repository](https://github.com/Miguelo981/tinder-api).
+Contributions are welcome! If you encounter issues, have ideas for improvements, or want to contribute new features, feel free to open an
+issue or submit a pull request on the [GitHub repository](https://github.com/Miguelo981/tinder-api).
 
 ### Guidelines:
 

--- a/deno.json
+++ b/deno.json
@@ -1,16 +1,23 @@
 {
-  "name": "@miguelo/tinder-api",
-  "version": "0.2.0",
-  "license": "MIT",
-  "exports": "./index.ts",
-  "tasks": {
-    "dev": "deno run --watch --allow-net test.ts",
-    "build": "deno run -A scripts/build-npm.ts 0.1.0"
-  },
-  "imports": {
-    "@/": "./src/",
-    "@deno/dnt": "jsr:@deno/dnt@^0.41.3",
-    "@std/assert": "jsr:@std/assert@1"
-  },
-  "nodeModulesDir": "auto"
+    "name": "@miguelo/tinder-api",
+    "version": "0.2.0",
+    "license": "MIT",
+    "exports": "./index.ts",
+    "tasks": {
+        "dev": "deno run --watch --allow-net test.ts",
+        "build": "deno run -A scripts/build-npm.ts 0.1.0"
+    },
+    "imports": {
+        "@/": "./src/",
+        "@deno/dnt": "jsr:@deno/dnt@^0.41.3",
+        "@std/assert": "jsr:@std/assert@1"
+    },
+    "fmt": {
+        "options": {
+            "lineWidth": 140,
+            "indentWidth": 4,
+            "singleQuote": true
+        }
+    },
+    "nodeModulesDir": "auto"
 }

--- a/deno.json
+++ b/deno.json
@@ -5,6 +5,7 @@
     "exports": "./index.ts",
     "tasks": {
         "dev": "deno run --watch --allow-net test.ts",
+        "test": "deno test --allow-net --allow-env --allow-read",
         "build": "deno run -A scripts/build-npm.ts 0.1.0"
     },
     "imports": {

--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,3 @@
-export { TinderAPI } from './src/tinder.ts'
-export * from '@/interfaces/index.ts'
-export * from '@/types.ts'
+export { TinderAPI } from './src/tinder.ts';
+export * from '@/interfaces/index.ts';
+export * from '@/types.ts';

--- a/scripts/build-npm.ts
+++ b/scripts/build-npm.ts
@@ -1,30 +1,30 @@
-import { build, emptyDir } from "@deno/dnt";
+import { build, emptyDir } from '@deno/dnt';
 
-await emptyDir("./npm");
+await emptyDir('./npm');
 
 await build({
-  entryPoints: ["./index.ts"],
-  outDir: "./npm",
-  shims: {
-    deno: true,
-  },
-  importMap: 'deno.json',
-  package: {
-    name: "tinder-api",
-    version: Deno.args[0],
-    description: "Unofficial Tinder API wrapper for Nodejs and Deno.",
-    keywords: ['api', 'nodejs', 'tinder', 'mrbeast', 'deno', 'tinder-api'],
-    license: "MIT",
-    repository: {
-      type: "git",
-      url: "git+https://github.com/Miguelo981/tinder-api.git",
+    entryPoints: ['./index.ts'],
+    outDir: './npm',
+    shims: {
+        deno: true,
     },
-    bugs: {
-      url: "https://github.com/Miguelo981/tinder-api/issues",
+    importMap: 'deno.json',
+    package: {
+        name: 'tinder-api',
+        version: Deno.args[0],
+        description: 'Unofficial Tinder API wrapper for Nodejs and Deno.',
+        keywords: ['api', 'nodejs', 'tinder', 'mrbeast', 'deno', 'tinder-api'],
+        license: 'MIT',
+        repository: {
+            type: 'git',
+            url: 'git+https://github.com/Miguelo981/tinder-api.git',
+        },
+        bugs: {
+            url: 'https://github.com/Miguelo981/tinder-api/issues',
+        },
     },
-  },
-  postBuild() {
-    Deno.copyFileSync("LICENSE", "npm/LICENSE");
-    Deno.copyFileSync("README.md", "npm/README.md");
-  },
+    postBuild() {
+        Deno.copyFileSync('LICENSE', 'npm/LICENSE');
+        Deno.copyFileSync('README.md', 'npm/README.md');
+    },
 });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,7 +6,7 @@ export const API_V = '/v2';
 
 export const TINDER_API_URL = new URL(BASE_PATH);
 
-type TinderRoute = 'profile' | 'search' | 'like' | 'dislike' | 'matches' | 'chatMessages' | 'sendMessage' | 'location';
+type TinderRoute = 'profile' | 'search' | 'like' | 'dislike' | 'matches' | 'chatMessages' | 'sendMessage' | 'location' | 'user';
 
 export const TINDER_ROUTER: Record<TinderRoute, Endpoint> = {
     profile: `${API_V}/profile`,
@@ -17,6 +17,7 @@ export const TINDER_ROUTER: Record<TinderRoute, Endpoint> = {
     chatMessages: `${API_V}/matches`,
     sendMessage: '/user/matches',
     location: `${API_V}/meta`,
+    user: '/user',
 };
 
 export const DEFAULT_LOCALE: Locale = 'es-ES';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -20,6 +20,32 @@ export const TINDER_ROUTER: Record<TinderRoute, Endpoint> = {
 };
 
 export const DEFAULT_LOCALE: Locale = 'es-ES';
-export const DEFAULT_SCOPES: ProfileScope[] = ['account', 'available_descriptors', 'boost', 'bouncerbypass', 'contact_cards', 'email_settings', 'feature_access', 'instagram', 'likes', 'profile_meter', 'notifications', 'misc_merchandising', 'offerings', 'onboarding', 'paywalls', 'plus_control', 'purchase', 'readreceipts', 'spotify', 'super_likes', 'tinder_u', 'travel', 'tutorials', 'user', 'all_in_gender']
+export const DEFAULT_SCOPES: ProfileScope[] = [
+    'account',
+    'available_descriptors',
+    'boost',
+    'bouncerbypass',
+    'contact_cards',
+    'email_settings',
+    'feature_access',
+    'instagram',
+    'likes',
+    'profile_meter',
+    'notifications',
+    'misc_merchandising',
+    'offerings',
+    'onboarding',
+    'paywalls',
+    'plus_control',
+    'purchase',
+    'readreceipts',
+    'spotify',
+    'super_likes',
+    'tinder_u',
+    'travel',
+    'tutorials',
+    'user',
+    'all_in_gender',
+];
 export const DEFAULT_MATCHES_COUNT = 60;
 export const DEFAULT_CHAT_MESSAGES_COUNT = 100;

--- a/src/interfaces/chat.ts
+++ b/src/interfaces/chat.ts
@@ -1,49 +1,49 @@
-import type { Locale, Meta } from "@/types.ts";
+import type { Locale, Meta } from '@/types.ts';
 
 export interface TinderSendMessageParams {
-    locale?: Locale
-    matchId: string
-    message: string
+    locale?: Locale;
+    matchId: string;
+    message: string;
 }
 
 export interface TinderSendMessaResponse {
-    _id:          string;
-    from:         string;
-    to:           string;
-    match_id:     string;
-    sent_date:    Date;
-    message:      string;
-    media:        Media;
+    _id: string;
+    from: string;
+    to: string;
+    match_id: string;
+    sent_date: Date;
+    message: string;
+    media: Media;
     created_date: Date;
 }
 
 export interface Media {
-    width:  null;
+    width: null;
     height: null;
 }
 
 export interface TinderChatMessagesParams {
-    locale?: Locale
-    count?: number
-    matchId: string
+    locale?: Locale;
+    count?: number;
+    matchId: string;
 }
 
 export interface TinderChatMessagesResponse {
     meta: Meta;
     data: {
-        messages: TinderMessage[]
-    }
+        messages: TinderMessage[];
+    };
 }
 
 export interface TinderMessage {
-    _id:          string;
-    match_id:     string;
-    sent_date:    Date;
-    message:      string;
-    to:           string;
-    from:         string;
+    _id: string;
+    match_id: string;
+    sent_date: Date;
+    message: string;
+    to: string;
+    from: string;
     created_date: Date;
-    timestamp:    number;
-    matchId:      string;
-    is_liked?:    boolean;
+    timestamp: number;
+    matchId: string;
+    is_liked?: boolean;
 }

--- a/src/interfaces/dislike.ts
+++ b/src/interfaces/dislike.ts
@@ -1,12 +1,12 @@
-import type { Locale } from "@/types.ts";
+import type { Locale } from '@/types.ts';
 
 export interface TinderDislikeParams {
-    locale?: Locale
-    userId: string
-    s_number: number
+    locale?: Locale;
+    userId: string;
+    s_number: number;
 }
 
 export interface TinderDislikeResponse {
-    'X-Padding': string
-    status: number
+    'X-Padding': string;
+    status: number;
 }

--- a/src/interfaces/edit-profile.ts
+++ b/src/interfaces/edit-profile.ts
@@ -1,17 +1,13 @@
 import { Locale } from '@/types.ts';
 import type { Algo, AllInGender, Asset, Badge, City, CropInfo, Image, Job, Photo, School, User } from '@/interfaces/shared.ts';
 
-type EditableUserFields = Pick<
-    User,
-    | 'bio'
-    | 'gender'
-    | 'show_gender_on_profile'
-    | 'custom_gender'
+type EditableUserFields = Partial<
+    Pick<User, 'bio' | 'gender' | 'show_gender_on_profile' | 'custom_gender'>
 >;
 
 export interface TinderEditProfileParams {
     locale?: Locale;
-    user: EditableUserFields & {
+    user?: EditableUserFields & {
         distance_filter?: number;
         age_filter_min?: number;
         age_filter_max?: number;

--- a/src/interfaces/edit-profile.ts
+++ b/src/interfaces/edit-profile.ts
@@ -1,0 +1,168 @@
+import { Locale } from '@/types.ts';
+import type { Algo, AllInGender, Asset, Badge, City, CropInfo, Image, Job, Photo, School, User } from '@/interfaces/shared.ts';
+
+type EditableUserFields = Pick<
+    User,
+    | 'bio'
+    | 'gender'
+    | 'show_gender_on_profile'
+    | 'custom_gender'
+>;
+
+export interface TinderEditProfileParams {
+    locale?: Locale;
+    user: EditableUserFields & {
+        distance_filter?: number;
+        age_filter_min?: number;
+        age_filter_max?: number;
+        discoverable?: boolean;
+        photo_optimizer_enabled?: boolean;
+        global_mode?: {
+            is_enabled: boolean;
+        };
+    };
+    plus_control?: {
+        hide_age: boolean;
+        hide_distance: boolean;
+        // recency Shows more recently active users
+        // optimal Scientifically proven to get you more matches
+        blend: 'optimal' | 'recency';
+        hide_ads: boolean;
+        // discovery settings to only people who already liked you
+        discoverable_party: 'liked';
+    };
+}
+
+type ExtendedPhoto = Photo & {
+    fbId: string;
+    faces_count?: number;
+    processed_by_yolo?: boolean;
+};
+
+export interface TinderEditProfileResponse {
+    meta: {
+        status: number;
+    };
+    data: {
+        user: {
+            _id: string;
+            age_filter_max: number;
+            age_filter_min: number;
+            birth_date: string;
+            create_date: string;
+            crm_id: string;
+            pos_info: {
+                state: {
+                    name: string;
+                    code: string;
+                };
+                country: {
+                    name: string;
+                    cc: string;
+                    alpha3: string;
+                };
+                timezone: string;
+            };
+            discoverable: boolean;
+            distance_filter: number;
+            global_mode: {
+                is_enabled: boolean;
+                display_language: string;
+                language_preferences: Array<{
+                    language: string;
+                    is_selected: boolean;
+                }>;
+            };
+            auto_expansion: {
+                age_toggle: boolean;
+                distance_toggle: boolean;
+            };
+            gender: -1 | 0 | 1;
+            all_in_gender: AllInGender[];
+            gender_filter: number;
+            show_gender_on_profile: boolean;
+            name: string;
+            photos: ExtendedPhoto[];
+            photos_processing: boolean;
+            photo_optimizer_enabled: boolean;
+            ping_time: string;
+            jobs: Job[];
+            schools: School[];
+            badges: Badge[];
+            phone_id: string;
+            interested_in: number[];
+            interested_in_genders: number[];
+            pos: {
+                lat: number;
+                lon: number;
+            };
+            billing_info: {
+                supported_payment_methods: string[];
+            };
+            autoplay_video: string;
+            top_picks_discoverable: boolean;
+            photo_tagging_enabled: boolean;
+            city: City & {
+                coords: {
+                    lat: number;
+                    lon: number;
+                };
+            };
+            show_orientation_on_profile: boolean;
+            show_same_orientation_first: {
+                checked: boolean;
+                should_show_option: boolean;
+            };
+            sexual_orientations: AllInGender[];
+            recommended_sort_discoverable: boolean;
+            selfie_verification: string;
+            id_dob_verification: string;
+            noonlight_protected: boolean;
+            sync_swipe_enabled: boolean;
+            sparks_quizzes: Array<{
+                section_id: string;
+                section_name: string;
+                quizzes: Array<{
+                    id: string;
+                    name: string;
+                    answer_details: any[];
+                    answers: any[];
+                    image_url: string;
+                }>;
+            }>;
+            selected_descriptors: Array<{
+                id: string;
+                name?: string;
+                type: string;
+                visibility: string;
+                icon_url: string;
+                icon_urls: Image[];
+                section_id: string;
+                section_name: string;
+                measurable_selection?: {
+                    value: number;
+                    unit_of_measure: string;
+                };
+                choice_selections?: Array<{
+                    id: string;
+                    name: string;
+                    style?: string;
+                    emoji?: string;
+                    icon_urls?: Image[];
+                    match_group_key?: string;
+                }>;
+            }>;
+            preference_filters: Record<string, any>;
+            mm_enabled: boolean;
+            user_prompts: {
+                section_name: string;
+                max_prompts: number;
+                prompts: any[];
+            };
+            has_face_photos: boolean;
+            has_redacted_enabled: boolean;
+            profile_image_tags: any[];
+            image_tags_excluded: any[];
+        };
+    };
+}

--- a/src/interfaces/like.ts
+++ b/src/interfaces/like.ts
@@ -1,18 +1,18 @@
-import type { Locale } from "@/types.ts";
+import type { Locale } from '@/types.ts';
 
-export type ContentType = 'photo'
+export type ContentType = 'photo';
 
 export interface TinderLikeParams {
-    locale?: Locale
-    userId: string
-    liked_content_id: string
-    liked_content_type: ContentType
-    s_number: number
+    locale?: Locale;
+    userId: string;
+    liked_content_id: string;
+    liked_content_type: ContentType;
+    s_number: number;
 }
 
 export interface TinderLikeResponse {
-    match: boolean,
-    likes_remaining: number,
-    'X-Padding': string
-    status: number
+    match: boolean;
+    likes_remaining: number;
+    'X-Padding': string;
+    status: number;
 }

--- a/src/interfaces/location.ts
+++ b/src/interfaces/location.ts
@@ -1,4 +1,4 @@
-import { Locale } from '@/types.ts';
+import type { Locale, Meta } from '@/types.ts';
 
 export interface TinderLocationParams {
     locale?: Locale;
@@ -6,165 +6,187 @@ export interface TinderLocationParams {
     lon: number;
 }
 
-export interface TinderLocationResponse {
-    meta: {
-        status: number;
+interface ReadReceipts {
+    enabled: boolean;
+}
+
+interface BiometricConsent {
+    consents: string[];
+    needs_consent: boolean;
+}
+
+interface VoterRegistration {
+    registration_open: boolean;
+    status: string;
+    state: string;
+    vote_by_mail_status: string;
+}
+
+interface ProfileSettings {
+    can_edit_jobs: boolean;
+    can_edit_schools: boolean;
+    can_edit_email: boolean;
+    can_add_photos_from_facebook: boolean;
+    can_show_common_connections: boolean;
+    school_name_max_length: number;
+    job_title_max_length: number;
+    company_name_max_length: number;
+}
+
+interface SuperLike {
+    enabled: boolean;
+    alc_mode: number;
+}
+
+interface LocationPrechecks {
+    codes: Array<{ code: number }>;
+}
+
+interface AgeVerification {
+    status: string;
+}
+
+interface SexualOrientations {
+    enabled: boolean;
+    excluded_orientations: string[];
+    orientations: string[];
+    is_pride_flame_enabled: boolean;
+}
+
+interface SuperBoost {
+    enabled: boolean;
+    duration: number;
+    intro_multiplier: number;
+    peak_hours_start_h: number;
+    peak_hours_start_m: number;
+    peak_hours_duration: number;
+    variant: number;
+    members_only_text: string;
+    p1: boolean;
+    entry_gold_home: boolean;
+    entry_upgrade: boolean;
+    show_discount: boolean;
+    show_per_hour: boolean;
+}
+
+interface SecretAdmirer {
+    enabled: boolean;
+    min_likes_count: number;
+    max_likes_count: number;
+    fetch_secret_admirer_on_card: number;
+    reveal_like_variant: number;
+    reveal_like_min_likes_count: number;
+}
+
+interface FastMatch {
+    enabled: boolean;
+    preview_minimum_time: number;
+    notif_options: number[];
+    notif_defaults: number;
+    new_count_fetch_interval: number;
+    boost_new_count_fetch_interval: number;
+    new_count_threshold: number;
+    polling_mode: number;
+    entry_point: boolean;
+    controlla_optimization: boolean;
+    secret_admirer: SecretAdmirer;
+    use_teaser_endpoint: boolean;
+}
+
+interface ClientResources {
+    rate_card: {
+        carousel: Array<{ slug: string }>;
     };
+    plus_screen: string[];
+    platinum_paywall_carousel: string[];
+}
+
+interface Boost {
+    enabled: boolean;
+    duration: number;
+    intro_multiplier: number;
+    use_new_copy: boolean;
+}
+
+interface BiometricLiveness {
+    state: string;
+}
+
+interface TypingIndicator {
+    typing_heartbeat: number;
+    typing_ttl: number;
+}
+
+interface TopPicksOffsets {
+    offset0: number;
+    offset1: number;
+    offset2: number;
+    offset3: number;
+}
+
+interface TopPicks {
+    enabled: boolean;
+    local_daily_enabled: boolean;
+    local_daily_msg: string;
+    local_daily_offsets: TopPicksOffsets;
+    free_daily: boolean;
+    num_free_rated_limit: number;
+    refresh_interval: number;
+    lookahead: number;
+    post_swipe_paywall: boolean;
+    top_picks_categories_enabled: boolean;
+}
+
+interface Account {
+    email_prompt_required: boolean;
+    email_prompt_dismissible: boolean;
+    email_prompt_show_marketing_opt_in: boolean;
+    email_prompt_show_strict_opt_in: boolean;
+    fireboarding: boolean;
+}
+
+interface CrmInbox {
+    enabled: boolean;
+}
+
+interface ChatSuggestionConsent {
+    consents: string[];
+    needs_consent: boolean;
+}
+
+export interface TinderLocationResponse {
+    meta: Meta;
     data: {
-        readreceipts: {
-            enabled: boolean;
-        };
-        biometric_consent: {
-            consents: string[];
-            needs_consent: boolean;
-        };
-        voter_registration: {
-            registration_open: boolean;
-            status: string;
-            state: string;
-            vote_by_mail_status: string;
-        };
-        profile: {
-            can_edit_jobs: boolean;
-            can_edit_schools: boolean;
-            can_edit_email: boolean;
-            can_add_photos_from_facebook: boolean;
-            can_show_common_connections: boolean;
-            school_name_max_length: number;
-            job_title_max_length: number;
-            company_name_max_length: number;
-        };
-        super_like: {
-            enabled: boolean;
-            alc_mode: number;
-        };
-        location_prechecks: {
-            codes: Array<{
-                code: number;
-            }>;
-        };
-        age_verification: {
-            status: string;
-        };
-        sexual_orientations: {
-            enabled: boolean;
-            excluded_orientations: string[];
-            orientations: string[];
-            is_pride_flame_enabled: boolean;
-        };
-        gold_homepage: {
-            enabled: boolean;
-        };
-        super_boost: {
-            enabled: boolean;
-            duration: number;
-            intro_multiplier: number;
-            peak_hours_start_h: number;
-            peak_hours_start_m: number;
-            peak_hours_duration: number;
-            variant: number;
-            members_only_text: string;
-            p1: boolean;
-            entry_gold_home: boolean;
-            entry_upgrade: boolean;
-            show_discount: boolean;
-            show_per_hour: boolean;
-        };
-        intro_pricing: {
-            enabled: boolean;
-        };
-        multi_photo: {
-            enabled: boolean;
-        };
-        message_consent: {
-            consents: string[];
-            needs_consent: boolean;
-        };
+        readreceipts: ReadReceipts;
+        biometric_consent: BiometricConsent;
+        voter_registration: VoterRegistration;
+        profile: ProfileSettings;
+        super_like: SuperLike;
+        location_prechecks: LocationPrechecks;
+        age_verification: AgeVerification;
+        sexual_orientations: SexualOrientations;
+        gold_homepage: { enabled: boolean };
+        super_boost: SuperBoost;
+        intro_pricing: { enabled: boolean };
+        multi_photo: { enabled: boolean };
+        message_consent: BiometricConsent;
         terms_of_service: {
             enabled: boolean;
             needs_accept: boolean;
             version: string;
         };
-        fast_match: {
-            enabled: boolean;
-            preview_minimum_time: number;
-            notif_options: number[];
-            notif_defaults: number;
-            new_count_fetch_interval: number;
-            boost_new_count_fetch_interval: number;
-            new_count_threshold: number;
-            polling_mode: number;
-            entry_point: boolean;
-            controlla_optimization: boolean;
-            secret_admirer: {
-                enabled: boolean;
-                min_likes_count: number;
-                max_likes_count: number;
-                fetch_secret_admirer_on_card: number;
-                reveal_like_variant: number;
-                reveal_like_min_likes_count: number;
-            };
-            use_teaser_endpoint: boolean;
-        };
-        client_resources: {
-            rate_card: {
-                carousel: Array<{
-                    slug: string;
-                }>;
-            };
-            plus_screen: string[];
-            platinum_paywall_carousel: string[];
-        };
-        levers: Record<
-            string,
-            {
-                value: any;
-                p_id: string;
-            }
-        >;
-        boost: {
-            enabled: boolean;
-            duration: number;
-            intro_multiplier: number;
-            use_new_copy: boolean;
-        };
-        biometric_liveness: {
-            state: string;
-        };
-        typing_indicator: {
-            typing_heartbeat: number;
-            typing_ttl: number;
-        };
-        top_picks: {
-            enabled: boolean;
-            local_daily_enabled: boolean;
-            local_daily_msg: string;
-            local_daily_offsets: {
-                offset0: number;
-                offset1: number;
-                offset2: number;
-                offset3: number;
-            };
-            free_daily: boolean;
-            num_free_rated_limit: number;
-            refresh_interval: number;
-            lookahead: number;
-            post_swipe_paywall: boolean;
-            top_picks_categories_enabled: boolean;
-        };
-        account: {
-            email_prompt_required: boolean;
-            email_prompt_dismissible: boolean;
-            email_prompt_show_marketing_opt_in: boolean;
-            email_prompt_show_strict_opt_in: boolean;
-            fireboarding: boolean;
-        };
-        crm_inbox: {
-            enabled: boolean;
-        };
-        chat_suggestion_consent: {
-            consents: string[];
-            needs_consent: boolean;
-        };
+        fast_match: FastMatch;
+        client_resources: ClientResources;
+        levers: Record<string, {
+            value: any;
+            p_id: string;
+        }>;
+        boost: Boost;
+        biometric_liveness: BiometricLiveness;
+        typing_indicator: TypingIndicator;
+        top_picks: TopPicks;
+        account: Account;
+        crm_inbox: CrmInbox;
+        chat_suggestion_consent: ChatSuggestionConsent;
     };
 }

--- a/src/interfaces/matches.ts
+++ b/src/interfaces/matches.ts
@@ -1,60 +1,61 @@
-import type { Locale, Meta } from "@/types.ts";
+import type { Locale, Meta } from '@/types.ts';
+import type { Badge, Photo, Type as MediaTypeEnum } from '@/interfaces/shared.ts';
 
 export interface TinderMatchesParams {
-    locale?: Locale
-    count?: number
-    message?: number // 0 or 1, 0: no message, 1: message
-    isTinderU?: boolean
+    locale?: Locale;
+    count?: number;
+    message?: number; // 0 or 1, 0: no message, 1: message
+    isTinderU?: boolean;
 }
 
 export interface TinderMatchesResponse {
     meta: Meta;
     data: {
         matches: TinderMatch[];
-    }
+    };
 }
 
 export interface TinderMatch {
-    seen:                       Seen;
-    _id:                        string;
-    id:                         string;
-    closed:                     boolean;
-    common_friend_count:        number;
-    common_like_count:          number;
-    created_date:               Date;
-    dead:                       boolean;
-    last_activity_date:         Date;
-    message_count:              number;
-    messages:                   Message[];
-    participants:               string[];
-    pending:                    boolean;
-    is_super_like:              boolean;
-    is_boost_match:             boolean;
-    is_super_boost_match:       boolean;
-    is_primetime_boost_match:   boolean;
-    is_experiences_match:       boolean;
-    is_fast_match:              boolean;
-    is_preferences_match:       boolean;
-    is_matchmaker_match:        boolean;
-    is_lets_meet_match:         boolean;
-    is_opener:                  boolean;
+    seen: Seen;
+    _id: string;
+    id: string;
+    closed: boolean;
+    common_friend_count: number;
+    common_like_count: number;
+    created_date: Date;
+    dead: boolean;
+    last_activity_date: Date;
+    message_count: number;
+    messages: Message[];
+    participants: string[];
+    pending: boolean;
+    is_super_like: boolean;
+    is_boost_match: boolean;
+    is_super_boost_match: boolean;
+    is_primetime_boost_match: boolean;
+    is_experiences_match: boolean;
+    is_fast_match: boolean;
+    is_preferences_match: boolean;
+    is_matchmaker_match: boolean;
+    is_lets_meet_match: boolean;
+    is_opener: boolean;
     has_shown_initial_interest: boolean;
-    person:                     Person;
-    following:                  boolean;
-    following_moments:          boolean;
-    readreceipt:                Readreceipt;
-    subscription_tier?:         string;
-    liked_content?:             LikedContent;
-    explore_attribution?:       ExploreAttribution;
+    person: Person;
+    following: boolean;
+    following_moments: boolean;
+    readreceipt: Readreceipt;
+    subscription_tier?: string;
+    liked_content?: LikedContent;
+    explore_attribution?: ExploreAttribution;
 }
 
 export interface ExploreAttribution {
-    catalog_id:           string;
+    catalog_id: string;
     catalog_feature_type: string;
-    catalog_type:         string;
-    experience_title:     string;
-    logo_url:             string;
-    background_url:       string;
+    catalog_type: string;
+    experience_title: string;
+    logo_url: string;
+    background_url: string;
 }
 
 export interface LikedContent {
@@ -63,119 +64,41 @@ export interface LikedContent {
 }
 
 export interface ByCloser {
-    user_id:       string;
-    type:          string;
-    photo?:        PhotoElement;
+    user_id: string;
+    type: string;
+    photo?: Photo;
     is_swipe_note: boolean;
-}
-
-export interface PhotoElement {
-    id:                 string;
-    crop_info:          CropInfo;
-    url:                string;
-    processedFiles:     Processed[];
-    fileName?:          string;
-    extension:          Extension;
-    webp_qf?:           number[];
-    rank?:              number;
-    score?:             number;
-    win_count?:         number;
-    assets:             any[];
-    type:               MediaTypeEnum;
-    media_type?:        MediaTypeEnum;
-    selfie_verified?:   boolean;
-    replaced_media_id?: string;
-    processedVideos?:   Processed[];
-}
-
-export interface CropInfo {
-    processed_by_bullseye: boolean;
-    user_customized:       boolean;
-    user?:                 Algo;
-    algo?:                 Algo;
-    faces?:                Face[];
-}
-
-export interface Algo {
-    width_pct:    number;
-    x_offset_pct: number;
-    height_pct:   number;
-    y_offset_pct: number;
-}
-
-export interface Face {
-    algo:                    Algo;
-    bounding_box_percentage: number;
-}
-
-export enum Extension {
-    Jpg = "jpg",
-    JpgWebp = "jpg,webp",
-}
-
-export enum MediaTypeEnum {
-    Image = "image",
-    Video = "video",
-}
-
-export interface Processed {
-    url:    string;
-    height: number;
-    width:  number;
 }
 
 export interface ByOpener {
-    user_id:       string;
-    type:          string;
-    photo?:        ByOpenerPhoto;
+    user_id: string;
+    type: string;
+    photo?: Photo;
     is_swipe_note: boolean;
 }
 
-export interface ByOpenerPhoto {
-    id:             string;
-    crop_info:      CropInfo;
-    url:            string;
-    processedFiles: Processed[];
-    fileName?:      string;
-    extension:      Extension;
-    webp_qf:        number[];
-    rank:           number;
-    score:          number;
-    win_count:      number;
-    assets:         any[];
-    type:           MediaTypeEnum;
-}
-
 export interface Message {
-    _id:       string;
-    match_id:  string;
+    _id: string;
+    match_id: string;
     sent_date: Date;
-    message:   string;
-    to:        string;
-    from:      string;
+    message: string;
+    to: string;
+    from: string;
     timestamp: number;
-    matchId:   string;
+    matchId: string;
 }
 
 export interface Person {
-    _id:            string;
-    badges?:        Badge[];
-    bio?:           string;
-    birth_date:     Date;
-    gender:         number;
-    name:           string;
-    ping_time:      Date;
-    photos:         PhotoElement[];
+    _id: string;
+    badges?: Badge[];
+    bio?: string;
+    birth_date: Date;
+    gender: number;
+    name: string;
+    ping_time: Date;
+    photos: Photo[];
     hide_distance?: boolean;
-    hide_age?:      boolean;
-}
-
-export interface Badge {
-    type: BadgeType;
-}
-
-export enum BadgeType {
-    SelfieVerified = "selfie_verified",
+    hide_age?: boolean;
 }
 
 export interface Readreceipt {
@@ -183,6 +106,6 @@ export interface Readreceipt {
 }
 
 export interface Seen {
-    match_seen:        boolean;
+    match_seen: boolean;
     last_seen_msg_id?: string;
 }

--- a/src/interfaces/profile.ts
+++ b/src/interfaces/profile.ts
@@ -1,35 +1,36 @@
-import type { Locale, Meta } from "@/types.ts";
-import type { Asset, Badge, BadgeType, Image, Spotify, User } from "@/interfaces/search.ts";
+import type { Locale, Meta } from '@/types.ts';
+import type { Asset, Badge, BadgeType, Image, Spotify, User } from '@/interfaces/shared.ts';
 
-export type ProfileScope = 'account'
-  | 'available_descriptors'
-  | 'boost'
-  | 'bouncerbypass'
-  | 'contact_cards'
-  | 'email_settings'
-  | 'feature_access'
-  | 'instagram'
-  | 'likes'
-  | 'profile_meter'
-  | 'notifications'
-  | 'misc_merchandising'
-  | 'offerings'
-  | 'onboarding'
-  | 'paywalls'
-  | 'plus_control'
-  | 'purchase'
-  | 'readreceipts'
-  | 'spotify'
-  | 'super_likes'
-  | 'tinder_u'
-  | 'travel'
-  | 'tutorials'
-  | 'user'
-  | 'all_in_gender'
+export type ProfileScope =
+    | 'account'
+    | 'available_descriptors'
+    | 'boost'
+    | 'bouncerbypass'
+    | 'contact_cards'
+    | 'email_settings'
+    | 'feature_access'
+    | 'instagram'
+    | 'likes'
+    | 'profile_meter'
+    | 'notifications'
+    | 'misc_merchandising'
+    | 'offerings'
+    | 'onboarding'
+    | 'paywalls'
+    | 'plus_control'
+    | 'purchase'
+    | 'readreceipts'
+    | 'spotify'
+    | 'super_likes'
+    | 'tinder_u'
+    | 'travel'
+    | 'tutorials'
+    | 'user'
+    | 'all_in_gender';
 
 export interface TinderProfileParams {
-    locale?: Locale
-    scopes: ProfileScope[]
+    locale?: Locale;
+    scopes: ProfileScope[];
 }
 
 export interface TinderProfileResponse {
@@ -38,132 +39,132 @@ export interface TinderProfileResponse {
 }
 
 export interface TinderProfileData {
-    account:               Account;
+    account: Account;
     available_descriptors: AvailableDescriptor[];
-    boost:                 PurpleBoost;
-    bouncerbypass:         Bouncerbypass;
-    contact_cards:         ContactCards;
-    email_settings:        DataEmailSettings;
-    feature_access:        FeatureAccess;
-    instagram:             Instagram;
-    likes:                 Likes;
-    profile_meter:         ProfileMeter;
-    notifications:         any[];
-    offerings:             Offerings;
-    onboarding:            Onboarding;
-    paywalls:              Paywall[];
-    plus_control:          PlusControl;
-    purchase:              DataPurchase;
-    readreceipts:          Readreceipts;
-    spotify:               Spotify;
-    super_likes:           SuperLikes;
-    tinder_u:              TinderU;
-    travel:                Travel;
-    tutorials:             string[];
-    user:                  User;
-    all_in_gender:         DataAllInGender[];
-    misc_merchandising:    MiscMerchandising;
+    boost: PurpleBoost;
+    bouncerbypass: Bouncerbypass;
+    contact_cards: ContactCards;
+    email_settings: DataEmailSettings;
+    feature_access: FeatureAccess;
+    instagram: Instagram;
+    likes: Likes;
+    profile_meter: ProfileMeter;
+    notifications: any[];
+    offerings: Offerings;
+    onboarding: Onboarding;
+    paywalls: Paywall[];
+    plus_control: PlusControl;
+    purchase: DataPurchase;
+    readreceipts: Readreceipts;
+    spotify: Spotify;
+    super_likes: SuperLikes;
+    tinder_u: TinderU;
+    travel: Travel;
+    tutorials: string[];
+    user: User;
+    all_in_gender: DataAllInGender[];
+    misc_merchandising: MiscMerchandising;
 }
 
 export interface Account {
     account_phone_number: string;
-    apple_id_linked:      boolean;
-    facebook_id_linked:   boolean;
-    google_id_linked:     boolean;
-    line_id_linked:       boolean;
-    is_email_verified:    boolean;
-    account_email:        string;
+    apple_id_linked: boolean;
+    facebook_id_linked: boolean;
+    google_id_linked: boolean;
+    line_id_linked: boolean;
+    is_email_verified: boolean;
+    account_email: string;
 }
 
 export interface DataAllInGender {
-    checked:                           boolean;
-    parent_gender_id:                  number;
-    subheading:                        string;
-    id:                                string;
-    name:                              string;
-    children:                          Child[];
-    legacy_value?:                     number;
+    checked: boolean;
+    parent_gender_id: number;
+    subheading: string;
+    id: string;
+    name: string;
+    children: Child[];
+    legacy_value?: number;
     requires_binary_gender_selection?: boolean;
 }
 
 export interface Child {
-    checked:     boolean;
-    id:          string;
-    name:        string;
+    checked: boolean;
+    id: string;
+    name: string;
     description: string;
 }
 
 export interface AvailableDescriptor {
-    prompt?:      string;
-    descriptors:  Descriptor[];
-    section_id:   string;
+    prompt?: string;
+    descriptors: Descriptor[];
+    section_id: string;
     section_name: string;
     display_type: string;
 }
 
 export interface Descriptor {
-    id:                            string;
-    prompt?:                       string;
-    type:                          DescriptorType;
-    icon_url:                      string;
-    icon_urls:                     Image[];
-    background_text?:              string;
-    measurable_details?:           MeasurableDetails;
-    section_id:                    string;
-    section_name:                  string;
-    match_group_key?:              string;
+    id: string;
+    prompt?: string;
+    type: DescriptorType;
+    icon_url: string;
+    icon_urls: Image[];
+    background_text?: string;
+    measurable_details?: MeasurableDetails;
+    section_id: string;
+    section_name: string;
+    match_group_key?: string;
     discovery_preferences_enabled: boolean;
-    name?:                         string;
-    choices?:                      Choice[];
-    sub_prompt?:                   string;
-    should_localize_choices?:      boolean;
-    min_selections?:               number;
-    max_selections?:               number;
-    search_background_text?:       string;
+    name?: string;
+    choices?: Choice[];
+    sub_prompt?: string;
+    should_localize_choices?: boolean;
+    min_selections?: number;
+    max_selections?: number;
+    search_background_text?: string;
 }
 
 export interface Choice {
-    id:               string;
-    name:             string;
-    style?:           string;
-    emoji?:           string;
-    icon_urls?:       Image[];
+    id: string;
+    name: string;
+    style?: string;
+    emoji?: string;
+    icon_urls?: Image[];
     match_group_key?: string;
 }
 
 export interface MeasurableDetails {
-    min:                     number;
-    max:                     number;
-    unit_of_measure:         string;
+    min: number;
+    max: number;
+    unit_of_measure: string;
     default_unit_of_measure: string;
 }
 
 export enum DescriptorType {
-    ChoiceSelectorV1 = "choice_selector_v1",
-    Measurement = "measurement",
-    MultiSelectionSet = "multi_selection_set",
-    SingleSelectionSet = "single_selection_set",
+    ChoiceSelectorV1 = 'choice_selector_v1',
+    Measurement = 'measurement',
+    MultiSelectionSet = 'multi_selection_set',
+    SingleSelectionSet = 'single_selection_set',
 }
 
 export interface PurpleBoost {
-    allotment:                   number;
-    allotment_used:              number;
-    allotment_remaining:         number;
-    internal_remaining:          number;
-    is_super_boost:              boolean;
-    purchased_remaining:         number;
-    resets_at:                   number;
-    remaining:                   number;
-    duration:                    number;
-    boost_refresh_amount:        number;
-    boost_refresh_interval:      number;
+    allotment: number;
+    allotment_used: number;
+    allotment_remaining: number;
+    internal_remaining: number;
+    is_super_boost: boolean;
+    purchased_remaining: number;
+    resets_at: number;
+    remaining: number;
+    duration: number;
+    boost_refresh_amount: number;
+    boost_refresh_interval: number;
     boost_refresh_interval_unit: string;
-    compound_boost:              CompoundBoost[];
-    boost_ended:                 boolean;
-    result_viewed_at:            number;
-    boost_id:                    string;
-    multiplier:                  number;
-    consumed_from:               number;
+    compound_boost: CompoundBoost[];
+    boost_ended: boolean;
+    result_viewed_at: number;
+    boost_id: string;
+    multiplier: number;
+    consumed_from: number;
 }
 
 export interface CompoundBoost {
@@ -173,10 +174,10 @@ export interface CompoundBoost {
 
 export interface Bouncerbypass {
     purchased_bouncer_bypass_remaining: number;
-    internal_bouncer_bypass_remaining:  number;
+    internal_bouncer_bypass_remaining: number;
     allotment_bouncer_bypass_remaining: number;
-    total_bouncer_bypass_remaining:     number;
-    user_is_bounced:                    boolean;
+    total_bouncer_bypass_remaining: number;
+    user_is_bounced: boolean;
 }
 
 export interface ContactCards {
@@ -186,44 +187,44 @@ export interface ContactCards {
 
 export interface PopulatedCard {
     contact_type: string;
-    contact_id:   string;
-    deeplink?:    string;
-    default?:     boolean;
+    contact_id: string;
+    deeplink?: string;
+    default?: boolean;
 }
 
 export interface DataEmailSettings {
-    email:          string;
+    email: string;
     email_settings: EmailSettingsEmailSettings;
 }
 
 export interface EmailSettingsEmailSettings {
-    promotions:  boolean;
-    messages:    boolean;
+    promotions: boolean;
+    messages: boolean;
     new_matches: boolean;
 }
 
 export interface FeatureAccess {
-    likes_you:          DirectMessages;
-    passport:           Passport;
+    likes_you: DirectMessages;
+    passport: Passport;
     preference_filters: DirectMessages;
-    rewind:             Passport;
-    primetimeboost:     DirectMessages;
-    likes_you_annuity:  LikesYouAnnuity;
-    match_extension:    MatchExtension;
-    direct_messages:    DirectMessages;
-    likes_you_alc:      LikesYouAlc;
-    swipe_note:         DirectMessages;
+    rewind: Passport;
+    primetimeboost: DirectMessages;
+    likes_you_annuity: LikesYouAnnuity;
+    match_extension: MatchExtension;
+    direct_messages: DirectMessages;
+    likes_you_alc: LikesYouAlc;
+    swipe_note: DirectMessages;
 }
 
 export interface DirectMessages {
     unlimited: boolean;
-    amount:    number;
+    amount: number;
 }
 
 export interface LikesYouAlc {
-    amount:               number;
+    amount: number;
     show_paywall_on_card: number;
-    min_likes_count:      number;
+    min_likes_count: number;
 }
 
 export interface LikesYouAnnuity {
@@ -232,7 +233,7 @@ export interface LikesYouAnnuity {
 
 export interface MatchExtension {
     duration: number;
-    amount:   number;
+    amount: number;
 }
 
 export interface Passport {
@@ -247,31 +248,31 @@ export interface Likes {
 }
 
 export interface MiscMerchandising {
-    sub_expiration_banner:      SubExpirationBanner;
+    sub_expiration_banner: SubExpirationBanner;
     subscription_card_ordering: string[];
-    landing_card:               string;
+    landing_card: string;
 }
 
 export interface SubExpirationBanner {
-    heading:     string;
+    heading: string;
     description: string;
 }
 
 export interface Offerings {
-    plus:           Plus;
-    gold:           Gold;
-    platinum:       Gold;
-    swipenote:      Primetimeboost;
-    boost:          OfferingsBoost;
-    readreceipt:    Primetimeboost;
-    superboost:     Primetimeboost;
-    superlike:      OfferingsBoost;
+    plus: Plus;
+    gold: Gold;
+    platinum: Gold;
+    swipenote: Primetimeboost;
+    boost: OfferingsBoost;
+    readreceipt: Primetimeboost;
+    superboost: Primetimeboost;
+    superlike: OfferingsBoost;
     primetimeboost: Primetimeboost;
 }
 
 export interface OfferingsBoost {
     purchase_type: string;
-    product_data:  BoostProductDatum[];
+    product_data: BoostProductDatum[];
     merchandising: BoostMerchandising;
 }
 
@@ -280,176 +281,176 @@ export interface BoostMerchandising {
 }
 
 export interface BoostProductDatum {
-    amount:               number;
-    offer_type:           OfferType;
-    tags?:                Tag[];
-    icon_url?:            string;
-    payment_methods:      PaymentMethod[];
+    amount: number;
+    offer_type: OfferType;
+    tags?: Tag[];
+    icon_url?: string;
+    payment_methods: PaymentMethod[];
     original_product_id?: string;
-    duration?:            number;
+    duration?: number;
 }
 
 export enum OfferType {
-    Discount = "DISCOUNT",
-    Regular = "REGULAR",
+    Discount = 'DISCOUNT',
+    Regular = 'REGULAR',
 }
 
 export interface PaymentMethod {
-    platform:          Platform;
-    sku_id:            string;
-    discount:          number;
-    require_zip:       boolean;
-    price:             number;
-    is_vat:            boolean;
-    tax_rate:          number;
-    currency:          Currency;
+    platform: Platform;
+    sku_id: string;
+    discount: number;
+    require_zip: boolean;
+    price: number;
+    is_vat: boolean;
+    tax_rate: number;
+    currency: Currency;
     adjustment_price?: number;
 }
 
 export enum Currency {
-    Eur = "EUR",
+    Eur = 'EUR',
 }
 
 export enum Platform {
-    CreditCard = "credit_card",
+    CreditCard = 'credit_card',
 }
 
 export enum Tag {
-    BaseGroup = "BASE_GROUP",
-    BestValue = "BEST_VALUE",
-    MostPopular = "MOST_POPULAR",
-    Primary = "PRIMARY",
+    BaseGroup = 'BASE_GROUP',
+    BestValue = 'BEST_VALUE',
+    MostPopular = 'MOST_POPULAR',
+    Primary = 'PRIMARY',
 }
 
 export interface Gold {
     purchase_type: string;
-    product_data:  GoldProductDatum[];
+    product_data: GoldProductDatum[];
     merchandising: GoldMerchandising;
 }
 
 export interface GoldMerchandising {
-    data:                                        PurpleData;
-    ordering:                                    Ordering;
+    data: PurpleData;
+    ordering: Ordering;
     subscription_merchandising_comparison_chart: SubscriptionMerchandisingComparisonChart;
-    sub_page_data:                               PurpleSubPageData;
+    sub_page_data: PurpleSubPageData;
 }
 
 export interface PurpleData {
-    superlike:             SwipeNoteClass;
-    boost:                 SwipeNoteClass;
-    hide_ads:              Badge;
-    hide_age:              Badge;
-    hide_distance:         Badge;
-    like:                  Badge;
-    control_who_sees_you:  Badge;
-    passport:              Badge;
-    rewind:                Badge;
+    superlike: SwipeNoteClass;
+    boost: SwipeNoteClass;
+    hide_ads: Badge;
+    hide_age: Badge;
+    hide_distance: Badge;
+    like: Badge;
+    control_who_sees_you: Badge;
+    passport: Badge;
+    rewind: Badge;
     superboost_alc_access: Badge;
-    control_who_you_see:   Badge;
-    toppicks:              SwipeNoteClass;
-    toppicks_alc_access:   Badge;
-    likes_you:             Badge;
-    preference_filters:    Badge;
-    my_likes_lookback?:    MyLikesLookback;
-    priority_likes?:       Badge;
-    swipe_note?:           SwipeNoteClass;
+    control_who_you_see: Badge;
+    toppicks: SwipeNoteClass;
+    toppicks_alc_access: Badge;
+    likes_you: Badge;
+    preference_filters: Badge;
+    my_likes_lookback?: MyLikesLookback;
+    priority_likes?: Badge;
+    swipe_note?: SwipeNoteClass;
 }
 
 export interface SwipeNoteClass {
-    type:         string;
+    type: string;
     renewal_data: RenewalData;
 }
 
 export interface RenewalData {
-    balance:               number;
-    refresh_interval:      number;
+    balance: number;
+    refresh_interval: number;
     refresh_interval_unit: string;
 }
 
 export interface MyLikesLookback {
-    type:     BadgeType;
+    type: BadgeType;
     duration: number;
 }
 
 export interface Ordering {
-    carousel:    string[];
+    carousel: string[];
     plus_screen: string[];
 }
 
 export interface PurpleSubPageData {
-    cta:      string;
-    termed:   boolean;
+    cta: string;
+    termed: boolean;
     sections: Section[];
 }
 
 export interface Section {
-    type:     string;
-    heading:  string;
+    type: string;
+    heading: string;
     benefits: Benefit[];
 }
 
 export interface Benefit {
-    key:          string;
-    heading:      string;
-    included:     boolean;
+    key: string;
+    heading: string;
+    included: boolean;
     description?: string;
-    deeplink?:    string;
+    deeplink?: string;
 }
 
 export interface SubscriptionMerchandisingComparisonChart {
     base_subscription: string;
-    features:          Feature[];
+    features: Feature[];
 }
 
 export interface Feature {
-    text:                       string;
+    text: string;
     base_subscription_included: boolean;
 }
 
 export interface GoldProductDatum {
-    amount:                number;
-    offer_type:            OfferType;
-    refresh_interval:      number;
+    amount: number;
+    offer_type: OfferType;
+    refresh_interval: number;
     refresh_interval_unit: string;
-    tags:                  Tag[];
-    icon_url:              string;
-    payment_methods:       PaymentMethod[];
+    tags: Tag[];
+    icon_url: string;
+    payment_methods: PaymentMethod[];
 }
 
 export interface Plus {
     purchase_type: string;
-    product_data:  GoldProductDatum[];
+    product_data: GoldProductDatum[];
     merchandising: PlusMerchandising;
 }
 
 export interface PlusMerchandising {
-    data:          FluffyData;
-    ordering:      Ordering;
+    data: FluffyData;
+    ordering: Ordering;
     sub_page_data: FluffySubPageData;
 }
 
 export interface FluffyData {
-    superlike:             SwipeNoteClass;
-    boost:                 SwipeNoteClass;
-    hide_ads:              Badge;
-    hide_age:              Badge;
-    hide_distance:         Badge;
-    like:                  Badge;
-    control_who_sees_you:  Badge;
-    passport:              Badge;
-    rewind:                Badge;
+    superlike: SwipeNoteClass;
+    boost: SwipeNoteClass;
+    hide_ads: Badge;
+    hide_age: Badge;
+    hide_distance: Badge;
+    like: Badge;
+    control_who_sees_you: Badge;
+    passport: Badge;
+    rewind: Badge;
     superboost_alc_access: Badge;
-    control_who_you_see:   Badge;
+    control_who_you_see: Badge;
 }
 
 export interface FluffySubPageData {
-    termed:   boolean;
+    termed: boolean;
     sections: Section[];
 }
 
 export interface Primetimeboost {
     purchase_type: string;
-    product_data:  BoostProductDatum[];
+    product_data: BoostProductDatum[];
     merchandising: Instagram;
 }
 
@@ -458,88 +459,88 @@ export interface Onboarding {
 }
 
 export interface Tutorial {
-    name:   string;
+    name: string;
     assets: Asset[];
 }
 
 export interface Paywall {
-    instanceID:              string;
-    templateID:              string;
-    productType:             string;
-    entryPoint:              string;
+    instanceID: string;
+    templateID: string;
+    productType: string;
+    entryPoint: string;
     carouselSubscriptionV2?: CarouselSubscriptionV2;
-    carouselBV2?:            CarouselBV2;
+    carouselBV2?: CarouselBV2;
 }
 
 export interface CarouselBV2 {
-    heroImage:       HeroImage;
-    upsellPrimary:   UpsellPrimary;
+    heroImage: HeroImage;
+    upsellPrimary: UpsellPrimary;
     upsellSecondary: UpsellSecondary;
-    title:           string;
-    body:            string;
-    discountTag:     string;
+    title: string;
+    body: string;
+    discountTag: string;
 }
 
 export interface HeroImage {
-    kind:    string;
+    kind: string;
     iconUrl: IconURL;
 }
 
 export interface IconURL {
-    dark:    string;
+    dark: string;
     default: string;
 }
 
 export interface UpsellPrimary {
-    title:                 string;
-    subtitle:              string;
-    deeplink:              string;
-    imageUrl:              IconURL;
-    productType:           string;
+    title: string;
+    subtitle: string;
+    deeplink: string;
+    imageUrl: IconURL;
+    productType: string;
     headerBackgroundColor: BorderColor;
-    borderColor:           BorderColor;
-    button:                Button;
+    borderColor: BorderColor;
+    button: Button;
 }
 
 export interface BorderColor {
-    type:     BorderColorType;
-    name:     string;
+    type: BorderColorType;
+    name: string;
     fallback: string;
 }
 
 export enum BorderColorType {
-    Color = "color",
-    Gradient = "gradient",
+    Color = 'color',
+    Gradient = 'gradient',
 }
 
 export interface Button {
-    text:         string;
-    textColor:    BorderColor;
-    background:   BorderColor;
+    text: string;
+    textColor: BorderColor;
+    background: BorderColor;
     borderColor?: BorderColor;
 }
 
 export interface UpsellSecondary {
-    heroImage:   HeroImage;
-    title:       string;
-    subtitle:    string;
-    deeplink:    string;
-    imageUrl:    IconURL;
+    heroImage: HeroImage;
+    title: string;
+    subtitle: string;
+    deeplink: string;
+    imageUrl: IconURL;
     productType: string;
-    cardHeader:  string;
+    cardHeader: string;
     description: string;
     borderColor: BorderColor;
-    button:      Button;
+    button: Button;
 }
 
 export interface CarouselSubscriptionV2 {
-    header:               Header;
-    title:                Title;
-    disclosureText:       string;
+    header: Header;
+    title: Title;
+    disclosureText: string;
     allotmentDisclosure?: AllotmentDisclosure;
-    discountTag:          string;
-    skuCard:              SkuCard;
-    button:               Button;
+    discountTag: string;
+    skuCard: SkuCard;
+    button: Button;
 }
 
 export interface AllotmentDisclosure {
@@ -552,46 +553,46 @@ export interface AllotmentDisclosureBoost {
 
 export interface Header {
     background: BorderColor;
-    iconUrl:    IconURL;
+    iconUrl: IconURL;
 }
 
 export interface SkuCard {
-    borderColor:            PurpleBorderColor;
+    borderColor: PurpleBorderColor;
     merchandisingTextColor: BorderColor;
-    iconUrl:                SkuCardIconURL;
+    iconUrl: SkuCardIconURL;
 }
 
 export interface PurpleBorderColor {
-    selected:   BorderColor;
+    selected: BorderColor;
     unselected: BorderColor;
 }
 
 export interface SkuCardIconURL {
-    newSub:  IconURL;
+    newSub: IconURL;
     upgrade: IconURL;
 }
 
 export interface Title {
-    text:      Text;
+    text: Text;
     textColor: BorderColor;
 }
 
 export interface Text {
-    boost?:                    string;
-    control_who_sees_you?:     string;
-    default:                   string;
-    hide_ads?:                 string;
-    hide_age_and_distance?:    string;
-    like?:                     string;
-    likes_you?:                string;
-    likes_you_filtering?:      string;
-    passport?:                 string;
-    preference_filters?:       string;
-    rewind?:                   string;
-    superlike?:                string;
-    toppicks?:                 string;
-    my_type?:                  string;
-    priority_likes?:           string;
+    boost?: string;
+    control_who_sees_you?: string;
+    default: string;
+    hide_ads?: string;
+    hide_age_and_distance?: string;
+    like?: string;
+    likes_you?: string;
+    likes_you_filtering?: string;
+    passport?: string;
+    preference_filters?: string;
+    rewind?: string;
+    superlike?: string;
+    toppicks?: string;
+    my_type?: string;
+    priority_likes?: string;
     superlike_attach_message?: string;
 }
 
@@ -600,58 +601,58 @@ export interface PlusControl {
 }
 
 export interface ProfileMeter {
-    percent_achieved:      number;
+    percent_achieved: number;
     incomplete_components: IncompleteComponent[];
 }
 
 export interface IncompleteComponent {
-    key:          string;
-    red_dot?:     boolean;
+    key: string;
+    red_dot?: boolean;
     display_text: string;
 }
 
 export interface DataPurchase {
-    purchases:            PurchaseElement[];
+    purchases: PurchaseElement[];
     subscription_expired: boolean;
-    payment_state:        number;
+    payment_state: number;
 }
 
 export interface PurchaseElement {
-    id:               string;
-    expire_date:      number;
-    payment_pending:  boolean;
-    product_type:     string;
-    purchase_type:    string;
-    product_id:       string;
-    terms:            number;
-    terms_unit:       string;
-    platform:         string;
-    is_grace_period:  boolean;
-    is_incentives:    boolean;
-    incentives_type:  string;
-    email:            string;
+    id: string;
+    expire_date: number;
+    payment_pending: boolean;
+    product_type: string;
+    purchase_type: string;
+    product_id: string;
+    terms: number;
+    terms_unit: string;
+    platform: string;
+    is_grace_period: boolean;
+    is_incentives: boolean;
+    incentives_type: string;
+    email: string;
     is_auto_renewing: boolean;
 }
 
 export interface Readreceipts {
-    internal_remaining:  number;
+    internal_remaining: number;
     purchased_remaining: number;
-    remaining:           number;
+    remaining: number;
 }
 
 export interface SuperLikes {
-    remaining:                       number;
-    alc_remaining:                   number;
-    new_alc_remaining:               number;
-    allotment:                       number;
-    superlike_refresh_amount:        number;
-    superlike_refresh_interval:      number;
+    remaining: number;
+    alc_remaining: number;
+    new_alc_remaining: number;
+    allotment: number;
+    superlike_refresh_amount: number;
+    superlike_refresh_interval: number;
     superlike_refresh_interval_unit: string;
-    resets_at:                       Date;
+    resets_at: Date;
 }
 
 export interface TinderU {
-    status:    string;
+    status: string;
     status_v2: string;
 }
 
@@ -660,8 +661,8 @@ export interface Travel {
 }
 
 export interface Country {
-    name:   string;
-    cc:     string;
+    name: string;
+    cc: string;
     alpha3: string;
 }
 

--- a/src/interfaces/search.ts
+++ b/src/interfaces/search.ts
@@ -1,7 +1,8 @@
-import type { Locale, RequestMethod, Meta } from "@/types.ts";
+import type { Locale, Meta } from '@/types.ts';
+import type { Spotify, User } from '@/interfaces/shared.ts';
 
 export interface TinderSearchParams {
-    locale?: Locale
+    locale?: Locale;
 }
 
 export interface TinderSearchResponse {
@@ -14,23 +15,23 @@ export interface TinderSearchData {
 }
 
 export interface TinderProfile {
-    type:                   ResultType;
-    user:                   User;
-    facebook:               Facebook;
-    spotify:                Spotify;
-    distance_mi:            number;
-    content_hash:           string;
-    s_number:               number;
-    teaser:                 ResultTeaser;
-    teasers:                ResultTeaser[];
-    experiment_info?:       ExperimentInfo;
-    is_superlike_upsell:    boolean;
-    live_ops?:              LiveOps;
-    tappy_content:          TappyContent[];
+    type: ResultType;
+    user: User;
+    facebook: Facebook;
+    spotify: Spotify;
+    distance_mi: number;
+    content_hash: string;
+    s_number: number;
+    teaser: ResultTeaser;
+    teasers: ResultTeaser[];
+    experiment_info?: ExperimentInfo;
+    is_superlike_upsell: boolean;
+    live_ops?: LiveOps;
+    tappy_content: TappyContent[];
     profile_detail_content: ProfileDetailContent[];
-    ui_configuration:       UIConfiguration;
-    user_posts:             any[];
-    mutuals?:               Mutuals;
+    ui_configuration: UIConfiguration;
+    user_posts: any[];
+    mutuals?: Mutuals;
 }
 
 export interface ExperimentInfo {
@@ -42,47 +43,47 @@ export interface UserInterests {
 }
 
 export interface SelectedInterest {
-    id:        string;
-    name:      string;
+    id: string;
+    name: string;
     is_common: boolean;
 }
 
 export interface Facebook {
     common_connections: any[];
-    connection_count:   number;
-    common_interests:   any[];
+    connection_count: number;
+    common_interests: any[];
 }
 
 export interface LiveOps {
     template_name: string;
-    teaser:        LiveOpsTeaser;
-    vibes:         Vibe[];
+    teaser: LiveOpsTeaser;
+    vibes: Vibe[];
 }
 
 export interface LiveOpsTeaser {
-    type:        string;
-    string:      string;
-    sub_string:  string;
+    type: string;
+    string: string;
+    sub_string: string;
     response_id: string;
 }
 
 export interface Vibe {
-    round:   number;
+    round: number;
     prompts: VibePrompt[];
 }
 
 export interface VibePrompt {
-    is_mutual:   boolean;
-    prompt:      string;
-    response:    string;
+    is_mutual: boolean;
+    prompt: string;
+    response: string;
     response_id: string;
 }
 
 export interface Mutuals {
-    mutuals_count:   number;
-    user_opt_in:     boolean;
-    rec_opt_in:      boolean;
-    mutuals:         any[];
+    mutuals_count: number;
+    user_opt_in: boolean;
+    rec_opt_in: boolean;
+    mutuals: any[];
     mystery_mutuals: MysteryMutuals;
 }
 
@@ -91,55 +92,8 @@ export interface MysteryMutuals {
 }
 
 export interface ProfileDetailContent {
-    content:         any[];
+    content: any[];
     page_content_id: string;
-}
-
-export interface Spotify {
-    spotify_connected:    boolean;
-    spotify_top_artists:  SpotifyTopArtist[];
-    spotify_theme_track?: Track;
-}
-
-export interface Track {
-    id:          string;
-    name:        string;
-    album:       Album;
-    artists:     AllInGender[];
-    preview_url: string;
-    uri:         string;
-}
-
-export interface Album {
-    id:     string;
-    name:   string;
-    images: Image[];
-}
-
-export interface Image {
-    height:   number;
-    width:    number;
-    url:      string;
-    quality?: Quality;
-}
-
-export enum Quality {
-    The1X = "1x",
-    The2X = "2x",
-    The3X = "3x",
-}
-
-export interface AllInGender {
-    id?:  string;
-    name: string;
-}
-
-export interface SpotifyTopArtist {
-    id:        string;
-    name:      string;
-    top_track: Track;
-    selected:  boolean;
-    images:    any[];
 }
 
 export interface TappyContent {
@@ -147,36 +101,36 @@ export interface TappyContent {
 }
 
 export interface Content {
-    id:    LocalAssetEnum;
+    id: LocalAssetEnum;
     type?: string;
 }
 
 export enum LocalAssetEnum {
-    Anthem = "anthem",
-    Bio = "bio",
-    City = "city",
-    Descriptors = "descriptors",
-    Distance = "distance",
-    Job = "job",
-    LiveOps = "live_ops",
-    Passions = "passions",
-    School = "school",
-    TopArtists = "top_artists",
+    Anthem = 'anthem',
+    Bio = 'bio',
+    City = 'city',
+    Descriptors = 'descriptors',
+    Distance = 'distance',
+    Job = 'job',
+    LiveOps = 'live_ops',
+    Passions = 'passions',
+    School = 'school',
+    TopArtists = 'top_artists',
 }
 
 export interface ResultTeaser {
     string: string;
-    type?:  TeaserType;
+    type?: TeaserType;
 }
 
 export enum TeaserType {
-    Job = "job",
-    JobPosition = "jobPosition",
-    School = "school",
+    Job = 'job',
+    JobPosition = 'jobPosition',
+    School = 'school',
 }
 
 export enum ResultType {
-    User = "user",
+    User = 'user',
 }
 
 export interface UIConfiguration {
@@ -193,8 +147,8 @@ export interface Distance {
 
 export interface TextV1 {
     content: string;
-    icon:    Icon;
-    style:   TextV1Style;
+    icon: Icon;
+    style: TextV1Style;
 }
 
 export interface Icon {
@@ -202,266 +156,9 @@ export interface Icon {
 }
 
 export enum TextV1Style {
-    IdentityV1 = "identity_v1",
-}
-
-export interface User {
-    _id:                     string;
-    badges:                  Badge[];
-    bio:                     string;
-    birth_date:              Date;
-    name:                    string;
-    photos:                  Photo[];
-    gender:                  -1 | 0 | 1;
-    jobs:                    Job[];
-    schools:                 AllInGender[];
-    city?:                   City;
-    show_gender_on_profile?: boolean;
-    online_now?:             boolean;
-    selected_descriptors?:   SelectedDescriptor[];
-    is_traveling?:           boolean;
-    sparks_quizzes?:         SparksQuizz[];
-    relationship_intent?:    RelationshipIntent;
-    user_prompts?:           UserPrompts;
-    bumper_sticker_enabled?: boolean;
-    sexual_orientations?:    AllInGender[];
-    all_in_gender?:          AllInGender[];
-    custom_gender?:          string;
-    hide_age?:               boolean;
-    hide_distance?:          boolean;
-}
-
-export interface Badge {
-    type: BadgeType;
-}
-
-export enum BadgeType {
-    IDDobNotVerified = "id_dob_not_verified",
-    SelfieNotVerified = "selfie_not_verified",
-    Unlimited = "UNLIMITED",
-}
-
-export interface City {
-    name: string;
-}
-
-export interface Job {
-    company?: City;
-    title:    City;
-}
-
-export interface Photo {
-    id:              string;
-    crop_info:       CropInfo;
-    url:             string;
-    processedFiles:  Image[];
-    processedVideos: any[];
-    fileName?:       string;
-    extension:       Extension;
-    assets:          Asset[];
-    media_type:      Type;
-}
-
-export interface Asset {
-    url:          string;
-    asset_type:   Type;
-    width:        number;
-    height:       number;
-    enhancements: Enhancement[];
-}
-
-export enum Type {
-    Image = "image",
-}
-
-export enum Enhancement {
-    Blurred = "blurred",
-}
-
-export interface CropInfo {
-    user?:                 Algo;
-    algo?:                 Algo;
-    processed_by_bullseye: boolean;
-    user_customized:       boolean;
-    faces?:                Face[];
-}
-
-export interface Algo {
-    width_pct:    number;
-    x_offset_pct: number;
-    height_pct:   number;
-    y_offset_pct: number;
-}
-
-export interface Face {
-    algo:                    Algo;
-    bounding_box_percentage: number;
-}
-
-export enum Extension {
-    Jpg = "jpg",
-    JpgWebp = "jpg,webp",
-}
-
-export interface RelationshipIntent {
-    descriptor_choice_id: string;
-    emoji:                string;
-    image_url:            string;
-    title_text:           string;
-    body_text:            string;
-    style:                string;
-    hidden_intent:        HiddenIntent;
-    tapped_action:        RelationshipIntentTappedAction;
-}
-
-export interface HiddenIntent {
-    emoji:      string;
-    image_url:  string;
-    title_text: string;
-    body_text:  string;
+    IdentityV1 = 'identity_v1',
 }
 
 export enum Emoji {
-    Empty = "\ud83d\udc40",
-}
-
-export interface RelationshipIntentTappedAction {
-    method:       RequestMethod;
-    url:          string;
-    query_params: PurpleQueryParams;
-}
-
-export interface PurpleQueryParams {
-    component_id: string;
-}
-
-export interface SelectedDescriptor {
-    id:                    string;
-    name?:                 string;
-    prompt?:               string;
-    type:                  SelectedDescriptorType;
-    icon_url:              string;
-    icon_urls:             Image[];
-    choice_selections?:    ChoiceSelection[];
-    section_id:            SectionID;
-    section_name:          SectionName;
-    measurable_selection?: MeasurableSelection;
-}
-
-export interface ChoiceSelection {
-    id:               string;
-    name:             string;
-    match_group_key?: string;
-}
-
-export interface MeasurableSelection {
-    value:           number;
-    min:             number;
-    max:             number;
-    unit_of_measure: UnitOfMeasure;
-}
-
-export enum UnitOfMeasure {
-    CM = "cm",
-}
-
-export enum SectionID {
-    SEC1 = "sec_1",
-    SEC2 = "sec_2",
-    SEC3 = "sec_3",
-    SEC4 = "sec_4",
-    SEC5 = "sec_5",
-    SEC6 = "sec_6",
-}
-
-export enum SectionName {
-    Basics = "Basics",
-    Height = "Height",
-    LanguagesIKnow = "Languages I Know",
-    Lifestyle = "Lifestyle",
-    Pronouns = "Pronouns",
-    RelationshipType = "Relationship Type",
-}
-
-export enum SelectedDescriptorType {
-    Measurement = "measurement",
-    MultiSelectionSet = "multi_selection_set",
-    SingleSelectionSet = "single_selection_set",
-}
-
-export interface SparksQuizz {
-    quizzes:            Quiz[];
-    section_id:         string;
-    section_name:       string;
-    similarity_score:   SimilarityScore;
-    locked_button_text: string;
-}
-
-export interface Quiz {
-    id:               QuizID;
-    name:             string;
-    answers:          string[];
-    answer_details:   AnswerDetail[];
-    image_url:        string;
-    locked_image_url: string;
-    similarity_score: SimilarityScore;
-}
-
-export interface AnswerDetail {
-    emoji:       string;
-    prompt_text: string;
-    answer_id:   string;
-    answer_text: string;
-}
-
-export enum QuizID {
-    Qz1 = "qz_1",
-    Qz2 = "qz_2",
-    Qz3 = "qz_3",
-}
-
-export interface SimilarityScore {
-    text:             string;
-    style:            SimilarityScoreStyle;
-    image_url:        string;
-    title_text:       string;
-    prompt_text:      string;
-    you_prefer_text:  string;
-    they_prefer_text: string;
-}
-
-export enum SimilarityScoreStyle {
-    Blue = "blue",
-    Pink = "pink",
-    Yellow = "yellow",
-}
-
-export interface UserPrompts {
-    section_name: string;
-    prompts:      UserPromptsPrompt[];
-    add_prompt:   AddPrompt;
-}
-
-export interface AddPrompt {
-    text:          string;
-    tapped_action: AddPromptTappedAction;
-}
-
-export interface AddPromptTappedAction {
-    method:       RequestMethod;
-    url:          string;
-    query_params: FluffyQueryParams;
-}
-
-export interface FluffyQueryParams {
-    component_id: string;
-    type:         string;
-}
-
-export interface UserPromptsPrompt {
-    id:            string;
-    question_text: string;
-    answer_id:     string;
-    answer_text:   string;
-    image_url:     string;
+    Empty = '\ud83d\udc40',
 }

--- a/src/interfaces/shared.ts
+++ b/src/interfaces/shared.ts
@@ -1,0 +1,312 @@
+import type { RequestMethod } from '@/types.ts';
+
+export interface Image {
+    height: number;
+    width: number;
+    url: string;
+    quality?: Quality;
+}
+
+export enum Quality {
+    The1X = '1x',
+    The2X = '2x',
+    The3X = '3x',
+}
+
+export interface Asset {
+    url: string;
+    asset_type: Type;
+    width: number;
+    height: number;
+    enhancements: Enhancement[];
+}
+
+export enum Type {
+    Image = 'image',
+}
+
+export enum Enhancement {
+    Blurred = 'blurred',
+}
+
+export interface Badge {
+    type: BadgeType;
+}
+
+export enum BadgeType {
+    IDDobNotVerified = 'id_dob_not_verified',
+    SelfieNotVerified = 'selfie_not_verified',
+    Unlimited = 'UNLIMITED',
+}
+
+export interface Spotify {
+    spotify_connected: boolean;
+    spotify_top_artists: SpotifyTopArtist[];
+    spotify_theme_track?: Track;
+}
+
+export interface Track {
+    id: string;
+    name: string;
+    album: Album;
+    artists: AllInGender[];
+    preview_url: string;
+    uri: string;
+}
+
+export interface Album {
+    id: string;
+    name: string;
+    images: Image[];
+}
+
+export interface SpotifyTopArtist {
+    id: string;
+    name: string;
+    top_track: Track;
+    selected: boolean;
+    images: any[];
+}
+
+export interface User {
+    _id: string;
+    badges: Badge[];
+    bio: string;
+    birth_date: Date;
+    name: string;
+    photos: Photo[];
+    gender: -1 | 0 | 1;
+    jobs: Job[];
+    schools: School[];
+    city?: City;
+    show_gender_on_profile?: boolean;
+    online_now?: boolean;
+    selected_descriptors?: SelectedDescriptor[];
+    is_traveling?: boolean;
+    sparks_quizzes?: SparksQuizz[];
+    relationship_intent?: RelationshipIntent;
+    user_prompts?: UserPrompts;
+    bumper_sticker_enabled?: boolean;
+    sexual_orientations?: AllInGender[];
+    all_in_gender?: AllInGender[];
+    custom_gender?: string;
+    hide_age?: boolean;
+    hide_distance?: boolean;
+}
+
+export interface AllInGender {
+    id?: string;
+    name: string;
+}
+
+export interface City {
+    name: string;
+    region?: string;
+}
+
+export interface CompanyOrTitle {
+    name: string;
+    displayed?: boolean;
+}
+
+export type School = CompanyOrTitle;
+
+export interface Job {
+    company?: CompanyOrTitle;
+    title: CompanyOrTitle;
+}
+
+export interface Photo {
+    id: string;
+    crop_info: CropInfo;
+    url: string;
+    processedFiles: Image[];
+    fileName?: string;
+    extension: Extension;
+    assets: Asset[];
+    media_type: Type;
+}
+
+export interface CropInfo {
+    user?: Algo;
+    algo?: Algo;
+    processed_by_bullseye: boolean;
+    user_customized: boolean;
+    faces?: Face[];
+}
+
+export interface Algo {
+    width_pct: number;
+    x_offset_pct: number;
+    height_pct: number;
+    y_offset_pct: number;
+}
+
+export interface Face {
+    algo: Algo;
+    bounding_box_percentage: number;
+}
+
+export enum Extension {
+    Jpg = 'jpg',
+    JpgWebp = 'jpg,webp',
+}
+
+export interface SelectedDescriptor {
+    id: string;
+    name?: string;
+    prompt?: string;
+    type: SelectedDescriptorType;
+    icon_url: string;
+    icon_urls: Image[];
+    choice_selections?: ChoiceSelection[];
+    section_id: SectionID;
+    section_name: SectionName;
+    measurable_selection?: MeasurableSelection;
+}
+
+export interface ChoiceSelection {
+    id: string;
+    name: string;
+    match_group_key?: string;
+}
+
+export interface MeasurableSelection {
+    value: number;
+    min: number;
+    max: number;
+    unit_of_measure: UnitOfMeasure;
+}
+
+export enum UnitOfMeasure {
+    CM = 'cm',
+}
+
+export enum SectionID {
+    SEC1 = 'sec_1',
+    SEC2 = 'sec_2',
+    SEC3 = 'sec_3',
+    SEC4 = 'sec_4',
+    SEC5 = 'sec_5',
+    SEC6 = 'sec_6',
+}
+
+export enum SectionName {
+    Basics = 'Basics',
+    Height = 'Height',
+    LanguagesIKnow = 'Languages I Know',
+    Lifestyle = 'Lifestyle',
+    Pronouns = 'Pronouns',
+    RelationshipType = 'Relationship Type',
+}
+
+export enum SelectedDescriptorType {
+    Measurement = 'measurement',
+    MultiSelectionSet = 'multi_selection_set',
+    SingleSelectionSet = 'single_selection_set',
+}
+
+export interface SparksQuizz {
+    quizzes: Quiz[];
+    section_id: string;
+    section_name: string;
+    similarity_score: SimilarityScore;
+    locked_button_text: string;
+}
+
+export interface Quiz {
+    id: QuizID;
+    name: string;
+    answers: string[];
+    answer_details: AnswerDetail[];
+    image_url: string;
+    locked_image_url: string;
+    similarity_score: SimilarityScore;
+}
+
+export interface AnswerDetail {
+    emoji: string;
+    prompt_text: string;
+    answer_id: string;
+    answer_text: string;
+}
+
+export enum QuizID {
+    Qz1 = 'qz_1',
+    Qz2 = 'qz_2',
+    Qz3 = 'qz_3',
+}
+
+export interface SimilarityScore {
+    text: string;
+    style: SimilarityScoreStyle;
+    image_url: string;
+    title_text: string;
+    prompt_text: string;
+    you_prefer_text: string;
+    they_prefer_text: string;
+}
+
+export enum SimilarityScoreStyle {
+    Blue = 'blue',
+    Pink = 'pink',
+    Yellow = 'yellow',
+}
+
+export interface RelationshipIntent {
+    descriptor_choice_id: string;
+    emoji: string;
+    image_url: string;
+    title_text: string;
+    body_text: string;
+    style: string;
+    hidden_intent: HiddenIntent;
+    tapped_action: RelationshipIntentTappedAction;
+}
+
+export interface HiddenIntent {
+    emoji: string;
+    image_url: string;
+    title_text: string;
+    body_text: string;
+}
+
+export interface RelationshipIntentTappedAction {
+    method: RequestMethod;
+    url: string;
+    query_params: PurpleQueryParams;
+}
+
+export interface PurpleQueryParams {
+    component_id: string;
+}
+
+export interface UserPrompts {
+    section_name: string;
+    prompts: UserPromptsPrompt[];
+    add_prompt: AddPrompt;
+}
+
+export interface AddPrompt {
+    text: string;
+    tapped_action: AddPromptTappedAction;
+}
+
+export interface AddPromptTappedAction {
+    method: RequestMethod;
+    url: string;
+    query_params: FluffyQueryParams;
+}
+
+export interface FluffyQueryParams {
+    component_id: string;
+    type: string;
+}
+
+export interface UserPromptsPrompt {
+    id: string;
+    question_text: string;
+    answer_id: string;
+    answer_text: string;
+    image_url: string;
+}

--- a/src/interfaces/tinder.ts
+++ b/src/interfaces/tinder.ts
@@ -1,19 +1,28 @@
-import type { TinderSearchParams, TinderSearchResponse } from "@/interfaces/search.ts";
-import type { TinderLikeParams, TinderLikeResponse } from "@/interfaces/like.ts";
-import type { TinderDislikeParams, TinderDislikeResponse } from "@/interfaces/dislike.ts";
-import type { TinderProfileParams, TinderProfileResponse } from "@/interfaces/profile.ts";
-import type { TinderMatchesParams, TinderMatchesResponse } from "@/interfaces/matches.ts";
-import type { TinderLocationParams, TinderLocationResponse } from "@/interfaces/location.ts";
-import type { TinderSendMessageParams, TinderSendMessaResponse, TinderChatMessagesParams, TinderChatMessagesResponse } from "@/interfaces/chat.ts";
-import type { TinderResponse } from "@/types.ts";
+import type { TinderSearchParams, TinderSearchResponse } from '@/interfaces/search.ts';
+import type { TinderLikeParams, TinderLikeResponse } from '@/interfaces/like.ts';
+import type { TinderDislikeParams, TinderDislikeResponse } from '@/interfaces/dislike.ts';
+import type { TinderProfileParams, TinderProfileResponse } from '@/interfaces/profile.ts';
+import type { TinderMatchesParams, TinderMatchesResponse } from '@/interfaces/matches.ts';
+import type { TinderLocationParams, TinderLocationResponse } from '@/interfaces/location.ts';
+import type { TinderEditProfileParams, TinderEditProfileResponse } from '@/interfaces/edit-profile.ts';
+import type { TinderUserParams, TinderUserResponse } from '@/interfaces/user.ts';
+import type {
+    TinderChatMessagesParams,
+    TinderChatMessagesResponse,
+    TinderSendMessageParams,
+    TinderSendMessaResponse,
+} from '@/interfaces/chat.ts';
+import type { TinderResponse } from '@/types.ts';
 
 export interface ITinderAPI {
     search(params?: TinderSearchParams): Promise<TinderResponse<TinderSearchResponse>>;
     like(params?: TinderLikeParams): Promise<TinderResponse<TinderLikeResponse>>;
     dislike(params?: TinderDislikeParams): Promise<TinderResponse<TinderDislikeResponse>>;
-    profile(params?: TinderProfileParams): Promise<TinderResponse<TinderProfileResponse>>
-    getMatches(params?: TinderMatchesParams): Promise<TinderResponse<TinderMatchesResponse>>
-    getChatMessages(params?: TinderChatMessagesParams): Promise<TinderResponse<TinderChatMessagesResponse>>
-    sendChatMessage(params?: TinderSendMessageParams): Promise<TinderResponse<TinderSendMessaResponse>>
+    profile(params?: TinderProfileParams): Promise<TinderResponse<TinderProfileResponse>>;
+    getMatches(params?: TinderMatchesParams): Promise<TinderResponse<TinderMatchesResponse>>;
+    getChatMessages(params?: TinderChatMessagesParams): Promise<TinderResponse<TinderChatMessagesResponse>>;
+    sendChatMessage(params?: TinderSendMessageParams): Promise<TinderResponse<TinderSendMessaResponse>>;
     setLocation(params?: TinderLocationParams): Promise<TinderResponse<TinderLocationResponse>>;
+    editProfile(params: TinderEditProfileParams): Promise<TinderResponse<TinderEditProfileResponse>>;
+    getUser(params: TinderUserParams): Promise<TinderResponse<TinderUserResponse>>;
 }

--- a/src/interfaces/user.ts
+++ b/src/interfaces/user.ts
@@ -1,0 +1,51 @@
+import type { Asset, Badge, CompanyOrTitle, CropInfo, Image } from '@/interfaces/shared.ts';
+
+export interface TinderUserParams {
+    username: string;
+    locale?: string;
+}
+
+export interface TinderUserResponse {
+    _id: string;
+    badges: Badge[];
+    bio: string;
+    birth_date: string;
+    birth_date_info: string;
+    connection_count: number;
+    common_connections: any[];
+    interest_count: number;
+    common_interests: any[];
+    distance_mi: number;
+    jobs: Array<{
+        company: CompanyOrTitle;
+        title: CompanyOrTitle;
+    }>;
+    name: string;
+    photos: Array<{
+        id: string;
+        assets: Asset[];
+        type: string;
+        crop_info: CropInfo;
+        url: string;
+        processedFiles: Image[];
+        fileName: string;
+        extension: string;
+        webp_qf: number[];
+        phash: {
+            version: string;
+            value: number;
+        };
+        dhash: {
+            version: string;
+            value: number;
+        };
+    }>;
+    ping_time: string;
+    schools: null | any[];
+    teaser: {
+        string: string;
+    };
+    hide_age: boolean;
+    hide_distance: boolean;
+    status: number;
+}

--- a/src/tinder.ts
+++ b/src/tinder.ts
@@ -1,49 +1,63 @@
-import { DEFAULT_CHAT_MESSAGES_COUNT, DEFAULT_LOCALE, DEFAULT_MATCHES_COUNT, DEFAULT_SCOPES, TINDER_API_URL, TINDER_ROUTER } from "@/constants.ts";
-import type { ConfigurationParameters, Endpoint, TinderResponse, RequestParams } from "@/types.ts";
-import type { ITinderAPI } from "@/interfaces/tinder.ts";
-import type { ConfigurationOptions } from "@/types.ts";
-import type { TinderSearchParams, TinderSearchResponse } from "@/interfaces/search.ts";
-import type { TinderLikeParams, TinderLikeResponse } from "@/interfaces/like.ts";
-import type { TinderDislikeParams, TinderDislikeResponse } from "@/interfaces/dislike.ts";
-import type { TinderProfileParams, TinderProfileResponse } from "./interfaces/profile.ts";
-import type { TinderMatchesParams, TinderMatchesResponse } from "@/interfaces/matches.ts";
-import type { TinderChatMessagesParams, TinderChatMessagesResponse, TinderSendMessageParams, TinderSendMessaResponse } from "./interfaces/chat.ts";
-import type { TinderLocationParams, TinderLocationResponse } from "@/interfaces/location.ts";
+import {
+    DEFAULT_CHAT_MESSAGES_COUNT,
+    DEFAULT_LOCALE,
+    DEFAULT_MATCHES_COUNT,
+    DEFAULT_SCOPES,
+    TINDER_API_URL,
+    TINDER_ROUTER,
+} from '@/constants.ts';
+import type { ConfigurationParameters, Endpoint, RequestParams, TinderResponse } from '@/types.ts';
+import type { ITinderAPI } from '@/interfaces/tinder.ts';
+import type { ConfigurationOptions } from '@/types.ts';
+import type { TinderSearchParams, TinderSearchResponse } from '@/interfaces/search.ts';
+import type { TinderLikeParams, TinderLikeResponse } from '@/interfaces/like.ts';
+import type { TinderDislikeParams, TinderDislikeResponse } from '@/interfaces/dislike.ts';
+import type { TinderProfileParams, TinderProfileResponse } from './interfaces/profile.ts';
+import type { TinderMatchesParams, TinderMatchesResponse } from '@/interfaces/matches.ts';
+import type {
+    TinderChatMessagesParams,
+    TinderChatMessagesResponse,
+    TinderSendMessageParams,
+    TinderSendMessaResponse,
+} from './interfaces/chat.ts';
+import type { TinderLocationParams, TinderLocationResponse } from '@/interfaces/location.ts';
+import type { TinderEditProfileParams, TinderEditProfileResponse } from '@/interfaces/edit-profile.ts';
+import type { TinderUserParams, TinderUserResponse } from '@/interfaces/user.ts';
 
 export class TinderAPI implements ITinderAPI {
-    private baseUrl: URL = TINDER_API_URL
+    private baseUrl: URL = TINDER_API_URL;
     /**
-   * parameter for grant type
-   *
-   * @type name security name
-   * @memberof TinderAPI
-   */
+     * parameter for grant type
+     *
+     * @type name security name
+     * @memberof TinderAPI
+     */
     private xAuthToken?:
         | string
         | Promise<string>
         | ((name: string) => string)
-        | ((name: string) => Promise<string>)
+        | ((name: string) => Promise<string>);
     /**
-   * base options for axios calls
-   *
-   * @type {ConfigurationOptions}
-   * @memberof TinderAPI
-   */
-    private baseOptions?: ConfigurationOptions
+     * base options for axios calls
+     *
+     * @type {ConfigurationOptions}
+     * @memberof TinderAPI
+     */
+    private baseOptions?: ConfigurationOptions;
 
     constructor(param: ConfigurationParameters = { xAuthToken: '' }) {
         this.xAuthToken = param.xAuthToken;
 
         if (!this.baseOptions) {
             this.baseOptions = {
-                defaultLocale: DEFAULT_LOCALE
-            }
+                defaultLocale: DEFAULT_LOCALE,
+            };
         }
 
         this.baseOptions.headers = {
             'X-AUTH-TOKEN': this.xAuthToken,
             ...this.baseOptions.headers,
-        }
+        };
     }
 
     private async request({ method, endpoint, ...rest }: RequestParams) {
@@ -53,7 +67,7 @@ export class TinderAPI implements ITinderAPI {
             const options: RequestInit = {
                 headers,
                 method,
-            }
+            };
 
             if ('params' in rest && rest.params?.size! > 0) {
                 for (const key of rest.params?.keys() ?? []) {
@@ -65,7 +79,7 @@ export class TinderAPI implements ITinderAPI {
 
             const response = await this.sendRequest(url.toString(), options, data);
 
-            return this.processResponse(response)
+            return this.processResponse(response);
         } catch (error: any) {
             throw new Error(`Failed to make request: ${error.message}`);
         }
@@ -97,78 +111,74 @@ export class TinderAPI implements ITinderAPI {
             throw new Error(`HTTP error! status: ${response.status}`);
         }
 
-        return response
+        return response;
     }
 
     private async processResponse<T>(response: Response): Promise<TinderResponse<T>> {
-        let data: any
+        let data: any;
         const contentType = response.headers.get('content-type') ?? '';
 
         if (contentType.includes('application/json')) {
-            data = await response.json()
+            data = await response.json();
         } else {
-            data = await response.text()
+            data = await response.text();
         }
 
         return {
             data,
             response,
-        }
+        };
     }
 
     /**
-     *
      * @summary Get core search results
      * @param {TinderSearchParams} params
      * @returns {Promise<TinderResponse<TinderSearchResponse>>}
      */
     async search(params: TinderSearchParams = { locale: this.baseOptions?.defaultLocale }): Promise<TinderResponse<TinderSearchResponse>> {
-        const query = new URLSearchParams({ ...params })
+        const query = new URLSearchParams({ ...params });
         const data = await this.get<TinderResponse<TinderSearchResponse>>(TINDER_ROUTER.search, query);
 
-        return data
+        return data;
     }
 
     /**
-     * 
      * @summary Likes a profile
-     * @param {TinderLikeParams} params 
+     * @param {TinderLikeParams} params
      * @returns {Promise<TinderResponse<TinderLikeResponse>>}
      */
     async like(params: TinderLikeParams): Promise<TinderResponse<TinderLikeResponse>> {
-        const query = new URLSearchParams({ locale: params.locale ?? this.baseOptions?.defaultLocale! })
-        const url = `${TINDER_ROUTER.like}/${params?.userId}` as Endpoint
+        const query = new URLSearchParams({ locale: params.locale ?? this.baseOptions?.defaultLocale! });
+        const url = `${TINDER_ROUTER.like}/${params?.userId}` as Endpoint;
         const body = {
             s_number: params?.s_number,
             liked_content_id: params?.liked_content_id,
             liked_content_type: params?.liked_content_type,
-        }
+        };
         const data = await this.post<TinderResponse<TinderLikeResponse>>(url, body, query);
 
-        return data
+        return data;
     }
 
     /**
-     * 
      * @summary Dislikes a profile
-     * @param {TinderDislikeParams} params 
+     * @param {TinderDislikeParams} params
      * @returns {Promise<TinderResponse<TinderDislikeResponse>>}
      */
     async dislike(params: TinderDislikeParams): Promise<TinderResponse<TinderDislikeResponse>> {
         const query = new URLSearchParams({
             locale: params.locale ?? this.baseOptions?.defaultLocale ?? DEFAULT_LOCALE,
-            s_number: String(params.s_number)
-        })
-        const url = `${TINDER_ROUTER.dislike}/${params.userId}` as Endpoint
+            s_number: String(params.s_number),
+        });
+        const url = `${TINDER_ROUTER.dislike}/${params.userId}` as Endpoint;
         const data = await this.get<TinderResponse<TinderDislikeResponse>>(url, query);
 
-        return data
+        return data;
     }
 
     /**
-     * 
      * @summary Get authenticated profile
-     * @param {TinderProfileParams} params 
+     * @param {TinderProfileParams} params
      * @returns {Promise<TinderResponse<TinderProfileResponse>>}
      */
     async profile(params?: TinderProfileParams): Promise<TinderResponse<TinderProfileResponse>> {
@@ -178,12 +188,12 @@ export class TinderAPI implements ITinderAPI {
         });
         const data = await this.get<TinderResponse<TinderProfileResponse>>(TINDER_ROUTER.profile, query);
 
-        return data
+        return data;
     }
 
     /**
      * @summary Get authenticated matches
-     * @param {TinderMatchesParams} params 
+     * @param {TinderMatchesParams} params
      * @returns {Promise<TinderResponse<TinderMatchesResponse>>}
      */
     async getMatches(params?: TinderMatchesParams): Promise<TinderResponse<TinderMatchesResponse>> {
@@ -195,47 +205,49 @@ export class TinderAPI implements ITinderAPI {
         });
         const data = await this.get<TinderResponse<TinderMatchesResponse>>(TINDER_ROUTER.matches, query);
 
-        return data
+        return data;
     }
 
     /**
      * @summary Get match's chat messages
-     * @param {TinderChatMessagesParams} params 
+     * @param {TinderChatMessagesParams} params
      * @returns {Promise<TinderResponse<TinderChatMessagesResponse>>}
      */
-    async getChatMessages({ matchId, count = DEFAULT_CHAT_MESSAGES_COUNT, ...params }: TinderChatMessagesParams): Promise<TinderResponse<TinderChatMessagesResponse>> {
+    async getChatMessages(
+        { matchId, count = DEFAULT_CHAT_MESSAGES_COUNT, ...params }: TinderChatMessagesParams,
+    ): Promise<TinderResponse<TinderChatMessagesResponse>> {
         const query = new URLSearchParams({
             locale: params?.locale ?? this.baseOptions?.defaultLocale ?? DEFAULT_LOCALE,
             count: String(count),
         });
-        const url = `${TINDER_ROUTER.chatMessages}/${matchId}/messages` as Endpoint
+        const url = `${TINDER_ROUTER.chatMessages}/${matchId}/messages` as Endpoint;
         const data = await this.get<TinderResponse<TinderChatMessagesResponse>>(url, query);
 
-        return data
+        return data;
     }
 
     /**
      * @summary Get authenticated matches
-     * @param {TinderSendMessageParams} params 
+     * @param {TinderSendMessageParams} params
      * @returns {Promise<TinderResponse<TinderSendMessaResponse>>}
      */
     async sendChatMessage(params: TinderSendMessageParams): Promise<TinderResponse<TinderSendMessaResponse>> {
         const query = new URLSearchParams({
             locale: params?.locale ?? this.baseOptions?.defaultLocale ?? DEFAULT_LOCALE,
         });
-        const url = `${TINDER_ROUTER.sendMessage}/${params?.matchId}` as Endpoint
+        const url = `${TINDER_ROUTER.sendMessage}/${params?.matchId}` as Endpoint;
         const body = {
-            message: params.message
-        }
+            message: params.message,
+        };
         const data = await this.post<TinderResponse<TinderSendMessaResponse>>(url, body, query);
 
-        return data
+        return data;
     }
 
     /**
      * @summary Sets the user's location using a latitude and longitude.
      *
-     * @remarks
+     * @description
      * IMPORTANT: This request can only be made once every 10 minutes.
      * Any requests during the 10-minute wait period will not change the location.
      *
@@ -261,5 +273,38 @@ export class TinderAPI implements ITinderAPI {
 
         return data;
     }
-}
 
+    /**
+     * @summary Edit the authenticated user's profile
+     * @description plus_control will only work if you have Tinder Plus
+     * @param {TinderEditProfileParams} params
+     * @returns {Promise<TinderResponse<TinderEditProfileResponse>>}
+     */
+    async editProfile(params: TinderEditProfileParams): Promise<TinderResponse<TinderEditProfileResponse>> {
+        const query = new URLSearchParams({
+            locale: this.baseOptions?.defaultLocale ?? DEFAULT_LOCALE,
+        });
+        const data = await this.post<TinderResponse<TinderEditProfileResponse>>(
+            TINDER_ROUTER.profile,
+            params,
+            query,
+        );
+
+        return data;
+    }
+
+    /**
+     * @summary Get user profile by username
+     * @param {TinderUserParams} params
+     * @returns {Promise<TinderResponse<TinderUserResponse>>}
+     */
+    async getUser(params: TinderUserParams): Promise<TinderResponse<TinderUserResponse>> {
+        const query = new URLSearchParams({
+            locale: params?.locale ?? this.baseOptions?.defaultLocale ?? DEFAULT_LOCALE,
+        });
+        const url = `${TINDER_ROUTER.user}/${params.username}` as Endpoint;
+        const data = await this.get<TinderResponse<TinderUserResponse>>(url, query);
+
+        return data;
+    }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,35 +1,48 @@
 export type RequestMethod = 'GET' | 'POST';
-export type Endpoint = `/${string}`
+export type Endpoint = `/${string}`;
 
-export type Locale = 'es-ES' | 'en-US' | 'fr-FR' | 'pt-BR' | 'de-DE' | 'it-IT' | 'ja-JP' | 'ko-KR' | 'zh-CN' | 'zh-TW' | 'ru-RU' | 'pl-PL' | 'tr-TR'
+export type Locale =
+    | 'es-ES'
+    | 'en-US'
+    | 'fr-FR'
+    | 'pt-BR'
+    | 'de-DE'
+    | 'it-IT'
+    | 'ja-JP'
+    | 'ko-KR'
+    | 'zh-CN'
+    | 'zh-TW'
+    | 'ru-RU'
+    | 'pl-PL'
+    | 'tr-TR';
 
-export type TinderResponse<T> = { data: T, response: Response }
+export type TinderResponse<T> = { data: T; response: Response };
 
 export interface ConfigurationOptions {
     headers?: Headers | Record<string, string>;
-    defaultLocale: Locale
+    defaultLocale: Locale;
 }
 
 export interface ConfigurationParameters {
-    xAuthToken: string
-    baseOptions?: ConfigurationOptions
+    xAuthToken: string;
+    baseOptions?: ConfigurationOptions;
 }
 
-export type RequestParams = GetRquestParams | PostRquestParams
+export type RequestParams = GetRquestParams | PostRquestParams;
 
 export type GetRquestParams = {
-    method: 'GET',
-    params?: URLSearchParams
-    endpoint: Endpoint
-} 
+    method: 'GET';
+    params?: URLSearchParams;
+    endpoint: Endpoint;
+};
 
 export type PostRquestParams = {
-    method: 'POST',
+    method: 'POST';
     // @ts-ignore: Data could be anything
-    data: any
-    params?: URLSearchParams
-    endpoint: Endpoint
-} 
+    data: any;
+    params?: URLSearchParams;
+    endpoint: Endpoint;
+};
 
 export interface Meta {
     status: number;


### PR DESCRIPTION
Update introduces two new routes to the backend: a "Get User by Username" route for retrieving user details by their unique username and an "Edit User Profile" route for allowing users to update their profile information. Additionally, the project underwent full formatting using Deno's built-in formatter to ensure consistent code styling. Shared TypeScript interfaces were also introduced, enabling better type safety and reducing redundancy. 

PS: 
Currently, I don't know where to find the username to be used for the "Get User by Username" route, but the route does work if you type in a specific username.













