### PR TITLE
add superLike method

### DIFF
--- a/src/interfaces/superlike.ts
+++ b/src/interfaces/superlike.ts
@@ -1,0 +1,35 @@
+import type { Locale } from "@/types.ts";
+import type { ContentType } from "@/interfaces/like.ts";
+
+export interface TinderSuperLikeParams {
+    locale?: Locale
+    userId: string
+    liked_content_id: string
+    liked_content_type: ContentType
+    s_number: number
+}
+
+export interface TinderSuperLikeConsumptionExpiry {
+    amount: number
+    timestamp_ms: number
+    grant_type: string
+}
+
+export interface TinderSuperLikes {
+    remaining: number
+    alc_remaining: number
+    new_alc_remaining: number
+    allotment: number
+    superlike_refresh_amount: number
+    superlike_refresh_interval: number
+    superlike_refresh_interval_unit: string
+    resets_at: string
+    consumption_expiry: TinderSuperLikeConsumptionExpiry[]
+}
+
+export interface TinderSuperLikeResponse {
+    status: number
+    match: boolean
+    super_likes: TinderSuperLikes
+    'X-Padding': string
+}

--- a/src/interfaces/tinder.ts
+++ b/src/interfaces/tinder.ts
@@ -1,5 +1,6 @@
 import type { TinderSearchParams, TinderSearchResponse } from "@/interfaces/search.ts";
 import type { TinderLikeParams, TinderLikeResponse } from "@/interfaces/like.ts";
+import type { TinderSuperLikeParams, TinderSuperLikeResponse } from "@/interfaces/superlike.ts";
 import type { TinderDislikeParams, TinderDislikeResponse } from "@/interfaces/dislike.ts";
 import type { TinderProfileParams, TinderProfileResponse } from "@/interfaces/profile.ts";
 import type { TinderMatchesParams, TinderMatchesResponse } from "@/interfaces/matches.ts";
@@ -10,6 +11,7 @@ import type { TinderResponse } from "@/types.ts";
 export interface ITinderAPI {
     search(params?: TinderSearchParams): Promise<TinderResponse<TinderSearchResponse>>;
     like(params?: TinderLikeParams): Promise<TinderResponse<TinderLikeResponse>>;
+    superLike(params?: TinderSuperLikeParams): Promise<TinderResponse<TinderSuperLikeResponse>>;
     dislike(params?: TinderDislikeParams): Promise<TinderResponse<TinderDislikeResponse>>;
     profile(params?: TinderProfileParams): Promise<TinderResponse<TinderProfileResponse>>
     getMatches(params?: TinderMatchesParams): Promise<TinderResponse<TinderMatchesResponse>>

--- a/src/tinder.ts
+++ b/src/tinder.ts
@@ -4,6 +4,7 @@ import type { ITinderAPI } from "@/interfaces/tinder.ts";
 import type { ConfigurationOptions } from "@/types.ts";
 import type { TinderSearchParams, TinderSearchResponse } from "@/interfaces/search.ts";
 import type { TinderLikeParams, TinderLikeResponse } from "@/interfaces/like.ts";
+import type { TinderSuperLikeParams, TinderSuperLikeResponse } from "@/interfaces/superlike.ts";
 import type { TinderDislikeParams, TinderDislikeResponse } from "@/interfaces/dislike.ts";
 import type { TinderProfileParams, TinderProfileResponse } from "@/interfaces/profile.ts";
 import type { TinderMatchesParams, TinderMatchesResponse } from "@/interfaces/matches.ts";
@@ -146,7 +147,26 @@ export class TinderAPI implements ITinderAPI {
     }
 
     /**
-     * 
+     *
+     * @summary Super likes a profile
+     * @param {TinderSuperLikeParams} params
+     * @returns {Promise<TinderResponse<TinderSuperLikeResponse>>}
+     */
+    async superLike(params: TinderSuperLikeParams): Promise<TinderResponse<TinderSuperLikeResponse>> {
+        const query = new URLSearchParams({ locale: params.locale ?? this.baseOptions?.defaultLocale! })
+        const url = `${TINDER_ROUTER.like}/${params.userId}/super` as Endpoint
+        const body = {
+            s_number: params.s_number,
+            liked_content_id: params.liked_content_id,
+            liked_content_type: params.liked_content_type,
+        }
+        const data = await this.post<TinderResponse<TinderSuperLikeResponse>>(url, body, query);
+
+        return data
+    }
+
+    /**
+     *
      * @summary Dislikes a profile
      * @param {TinderDislikeParams} params 
      * @returns {Promise<TinderResponse<TinderDislikeResponse>>}


### PR DESCRIPTION
Adds a new `superLike` method to `TinderAPI` that hits
  `POST /like/{userId}/super?locale=...` with the standard
  swipe body (`s_number`, `liked_content_id`, `liked_content_type`).

  - New `src/interfaces/superlike.ts` with `TinderSuperLikeParams` and `TinderSuperLikeResponse` (plus `TinderSuperLikes` and `TinderSuperLikeConsumptionExpiry` to type the super_likes metadata returned by the API).
  - `superLike` mirrors the `like` pattern and reuses the existing POST wrapper, so `X-AUTH-TOKEN`, `Content-Type` and any extra headers passed via `baseOptions.headers` are applied automatically.
  - `ITinderAPI` updated to expose the new method.