### PR TITLE
feat: add programmatic SMS + email login flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,10 @@ accessing search results.
 ## Features
 
 -   Perform searches for profiles.
--   Like or dislike profiles.
+-   Like, dislike, or super-like profiles.
+-   Programmatic login via SMS + (optional) email verification — no need to extract the token manually.
 -   Retrieve authenticated user profile information.
+-   Retrieve matches and chat messages.
 -   Designed for flexibility and easy integration.
 
 ## Installation
@@ -103,6 +105,65 @@ console.log(persistentDeviceId);
 
 You must send this value in the `persistent-device-id` header in every request made by the client.
 
+## Programmatic Login
+
+As an alternative to extracting the `X-AUTH-TOKEN` manually, you can obtain it by logging in with your phone number. The library handles the protobuf flow, SMS OTP verification, and the optional email verification step (multi-factor) automatically.
+
+The `persistent-device-id` should be generated once and persisted between runs (use the same UUID for future logins to avoid being treated as a new device).
+
+### Quick login with callbacks
+
+```typescript
+import { LoginSession, TinderAPI } from 'tinder-api';
+
+const deviceId = '<your persistent device id>'; // persist this UUID between runs
+
+const session = new LoginSession({ persistentDeviceId: deviceId });
+
+const { apiToken } = await session.login({
+    phoneNumber: '34601381673',
+    getSmsCode: ({ otpLength }) => prompt(`SMS code (${otpLength} digits):`)!,
+    getEmailCode: ({ emailMasked, otpLength }) => {
+        console.log(`Code sent to ${emailMasked}`);
+        return prompt(`Email code (${otpLength} digits):`)!;
+    },
+});
+
+const api = new TinderAPI({
+    xAuthToken: apiToken,
+    baseOptions: {
+        defaultLocale: 'es-ES',
+        headers: { 'persistent-device-id': deviceId },
+    },
+});
+```
+
+The callbacks may be sync or async — `getSmsCode` and `getEmailCode` can pull the OTP from any source (a UI prompt, an SMS gateway webhook, IMAP polling, etc.). `getEmailCode` is optional: if Tinder requires email verification and no provider is supplied, a `TinderEmailRequiredError` is thrown instead.
+
+### Step-by-step login (manual control)
+
+If you prefer to drive each step explicitly:
+
+```typescript
+import { LoginSession, TinderEmailRequiredError, type LoginSuccessResponse } from 'tinder-api';
+
+const session = new LoginSession({ persistentDeviceId: deviceId });
+
+await session.requestSmsCode({ phoneNumber: '34601381673' });
+const smsCode = prompt('SMS code:')!;
+
+let auth: LoginSuccessResponse;
+try {
+    auth = await session.verifySmsCode({ phoneNumber: '34601381673', otpCode: smsCode });
+} catch (e) {
+    if (!(e instanceof TinderEmailRequiredError)) throw e;
+    const emailCode = prompt(`Email code (sent to ${e.challenge.emailMasked}):`)!;
+    auth = await session.verifyEmailCode({ emailCode, jwt: e.challenge.jwt });
+}
+
+console.log(auth.apiToken);
+```
+
 ## Usage
 
 ### Init API client example
@@ -136,17 +197,41 @@ const likeResponse = await api.like({
 });
 ```
 
+### Super-like a profile
+
+```typescript
+const superLikeResponse = await api.superLike({
+    s_number: profile.s_number,
+    userId: profile.user._id,
+    liked_content_id: profile.user.photos.at(0)?.id!,
+    liked_content_type: 'photo',
+});
+
+console.log(superLikeResponse.data.super_likes.remaining);
+```
+
 ## API Methods
 
 | Method                                                                                       | Description                                                                                          |
 | -------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
 | `search(params?: TinderSearchParams): Promise<TinderResponse<TinderSearchResponse>>`         | Search for profiles.                                                                                 |
 | `like(params: TinderLikeParams): Promise<TinderResponse<TinderLikeResponse>>`                | Like a profile.                                                                                      |
+| `superLike(params: TinderSuperLikeParams): Promise<TinderResponse<TinderSuperLikeResponse>>` | Super-like a profile.                                                                                |
 | `dislike(params: TinderDislikeParams): Promise<TinderResponse<TinderDislikeResponse>>`       | Dislike a profile.                                                                                   |
 | `profile(params?: TinderProfileParams): Promise<TinderResponse<TinderProfileResponse>>`      | Retrieve authenticated user profile.                                                                 |
 | `setLocation(params: TinderLocationParams): Promise<TinderResponse<TinderLocationResponse>>` | Sets the user's location using latitude and longitude. Note: Can only be used once every 10 minutes. |
 | `getMatches(params?: TinderMatchesParams): Promise<TinderResponse<TinderMatchesResponse>>` | Retrieve matches for the authenticated user. |
 | `getChatMessages(params: TinderChatMessagesParams): Promise<TinderResponse<TinderChatMessagesResponse>>` | Retrieve chat messages for a specific match. |
+
+### `LoginSession`
+
+| Method                                                                                                                          | Description                                                                                          |
+| ------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `new LoginSession(opts?: { persistentDeviceId?: string })`                                                                      | Create a login session. Auto-generates a `persistent-device-id` if not provided (persist it!).       |
+| `login(params): Promise<LoginSuccessResponse>`                                                                                   | Full orchestrated flow with `getSmsCode` / `getEmailCode` callbacks. Returns the `apiToken`.         |
+| `requestSmsCode(params: { phoneNumber, locale? }): Promise<SmsSentResponse>`                                                    | Triggers Tinder to send an SMS OTP to the phone number.                                              |
+| `verifySmsCode(params: { phoneNumber, otpCode, locale? }): Promise<LoginSuccessResponse>`                                       | Verifies the SMS OTP. May throw `TinderEmailRequiredError` if Tinder also requires email validation. |
+| `verifyEmailCode(params: { emailCode, jwt, locale? }): Promise<LoginSuccessResponse>`                                           | Verifies the email OTP (multi-factor). The `jwt` comes from `TinderEmailRequiredError.challenge`.    |
 
 ## Interfaces
 
@@ -168,6 +253,18 @@ Parameters for liking a profile.
 | `s_number`           | `string` | The session number for the request. |
 | `liked_content_id`   | `string` | The ID of the content to like.      |
 | `liked_content_type` | `string` | The type of content to like.        |
+
+### TinderSuperLikeParams
+
+Parameters for super-liking a profile.
+
+| Property             | Type     | Description                                |
+| -------------------- | -------- | ------------------------------------------ |
+| `userId`             | `string` | The ID of the profile to super-like.       |
+| `s_number`           | `number` | The session number for the request.        |
+| `liked_content_id`   | `string` | The ID of the content to super-like.       |
+| `liked_content_type` | `string` | The type of content to super-like.         |
+| `locale`             | `string` | Optional locale (defaults to client value).|
 
 ### TinderDislikeParams
 
@@ -212,6 +309,33 @@ Parameters for retrieving chat messages.
 | Property  | Type     | Description                    |
 | --------- | -------- | ------------------------------ |
 | `matchId` | `string` | The ID of the match to query.  |
+
+### Login types
+
+#### `SmsSentResponse`
+
+| Property         | Type     | Description                                        |
+| ---------------- | -------- | -------------------------------------------------- |
+| `phone`          | `string` | Phone number that received the SMS.                |
+| `otpLength`      | `number` | Expected number of digits of the SMS OTP (e.g. 6). |
+| `deliveryMethod` | `number` | Delivery method enum (1 = SMS).                    |
+
+#### `LoginSuccessResponse`
+
+| Property       | Type     | Description                                          |
+| -------------- | -------- | ---------------------------------------------------- |
+| `apiToken`     | `string` | The `X-AUTH-TOKEN` to pass to the `TinderAPI` client. |
+| `refreshToken` | `string` | JWT refresh token returned by Tinder.                |
+| `userId`       | `string` | Authenticated user's ObjectId.                       |
+| `createdAt`    | `number` | Timestamp (seconds) returned by the server.          |
+
+#### `EmailRequiredChallenge` (inside `TinderEmailRequiredError.challenge`)
+
+| Property      | Type     | Description                                                          |
+| ------------- | -------- | -------------------------------------------------------------------- |
+| `jwt`         | `string` | Challenge token — pass it back to `verifyEmailCode`.                 |
+| `emailMasked` | `string` | Masked email where the code was sent (e.g. `m******v@gmail.com`).    |
+| `otpLength`   | `number` | Expected number of digits of the email OTP.                          |
 
 ## Error Handling
 

--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,5 @@
 export { TinderAPI } from './src/tinder.ts'
+export { LoginSession, TinderCaptchaRequiredError, TinderEmailRequiredError, TinderLoginError } from './src/auth.ts'
+export type { SmsCodeProvider, EmailCodeProvider } from './src/auth.ts'
 export * from '@/interfaces/index.ts'
 export * from '@/types.ts'

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,0 +1,232 @@
+import { BASE_PATH, DEFAULT_LOCALE } from "@/constants.ts";
+import { decodeMessage, decodeString, encodeMessage, encodeString, type ProtoField } from "@/protobuf.ts";
+import type { Locale } from "@/types.ts";
+import type {
+    CaptchaChallenge,
+    EmailRequiredChallenge,
+    LoginSuccessResponse,
+    SmsSentResponse,
+} from "@/interfaces/auth.ts";
+
+export type SmsCodeProvider = (info: SmsSentResponse) => string | Promise<string>;
+export type EmailCodeProvider = (challenge: EmailRequiredChallenge) => string | Promise<string>;
+
+const AUTH_LOGIN_ENDPOINT = `${BASE_PATH}/v3/auth/login`;
+
+const MOBILE_HEADERS = {
+    'User-Agent': 'Tinder/15.13.0 (iPhone; iOS 17.5; Scale/3.00)',
+    'Content-Type': 'application/x-protobuf',
+    'Accept': 'application/x-protobuf',
+    'platform': 'ios',
+    'tinder-version': '15.13.0',
+    'app-version': '15130000',
+    'is-created-as-guest': 'false',
+    'x-supported-image-formats': 'webp,jpeg',
+} as const;
+
+export class TinderCaptchaRequiredError extends Error {
+    constructor(public readonly challenge: CaptchaChallenge) {
+        super('Tinder login requires CAPTCHA resolution (Arkose Labs).');
+        this.name = 'TinderCaptchaRequiredError';
+    }
+}
+
+export class TinderEmailRequiredError extends Error {
+    constructor(public readonly challenge: EmailRequiredChallenge) {
+        super(`Tinder login requires email verification (code sent to ${challenge.emailMasked}).`);
+        this.name = 'TinderEmailRequiredError';
+    }
+}
+
+export class TinderLoginError extends Error {
+    constructor(message: string, public readonly status?: number, public readonly body?: string) {
+        super(message);
+        this.name = 'TinderLoginError';
+    }
+}
+
+export class LoginSession {
+    public readonly persistentDeviceId: string;
+    private readonly appSessionId: string;
+    private readonly funnelSessionId: string;
+    private readonly startedAt: number;
+
+    constructor(opts?: { persistentDeviceId?: string }) {
+        this.persistentDeviceId = opts?.persistentDeviceId ?? crypto.randomUUID();
+        this.appSessionId = crypto.randomUUID();
+        this.funnelSessionId = crypto.randomUUID().replace(/-/g, '').slice(0, 16);
+        this.startedAt = Date.now();
+    }
+
+    async requestSmsCode(params: { phoneNumber: string; locale?: Locale }): Promise<SmsSentResponse> {
+        const phoneRequest = encodeString(1, params.phoneNumber);
+        const body = new Uint8Array(encodeMessage(1, phoneRequest));
+        const responseBytes = await this.send(body, params.locale);
+        return this.parseResponse(responseBytes, (f) => {
+            if (f.field === 4 && f.value instanceof Uint8Array) return parseSmsSent(f.value);
+            return undefined;
+        }, 'sms_sent');
+    }
+
+    async verifySmsCode(params: { phoneNumber: string; otpCode: string; locale?: Locale }): Promise<LoginSuccessResponse> {
+        const phoneRequest = encodeString(1, params.phoneNumber);
+        const otpBody = [
+            ...encodeMessage(1, phoneRequest),
+            ...encodeString(2, params.otpCode),
+        ];
+        const body = new Uint8Array(encodeMessage(2, otpBody));
+        const responseBytes = await this.send(body, params.locale);
+        return this.parseResponse(responseBytes, (f) => {
+            if (f.field === 8 && f.value instanceof Uint8Array) return parseAuthSuccess(f.value);
+            return undefined;
+        }, 'success');
+    }
+
+    async verifyEmailCode(params: { emailCode: string; jwt: string; locale?: Locale }): Promise<LoginSuccessResponse> {
+        const challengeProof = encodeString(1, params.jwt);
+        const emailBody = [
+            ...encodeString(2, params.emailCode),
+            ...encodeMessage(3, challengeProof),
+        ];
+        const body = new Uint8Array(encodeMessage(5, emailBody));
+        const responseBytes = await this.send(body, params.locale);
+        return this.parseResponse(responseBytes, (f) => {
+            if (f.field === 8 && f.value instanceof Uint8Array) return parseAuthSuccess(f.value);
+            return undefined;
+        }, 'success');
+    }
+
+    async login(params: {
+        phoneNumber: string;
+        locale?: Locale;
+        getSmsCode: SmsCodeProvider;
+        getEmailCode?: EmailCodeProvider;
+    }): Promise<LoginSuccessResponse> {
+        const smsInfo = await this.requestSmsCode({ phoneNumber: params.phoneNumber, locale: params.locale });
+        const otpCode = await params.getSmsCode(smsInfo);
+        try {
+            return await this.verifySmsCode({ phoneNumber: params.phoneNumber, otpCode, locale: params.locale });
+        } catch (e) {
+            if (e instanceof TinderEmailRequiredError && params.getEmailCode) {
+                const emailCode = await params.getEmailCode(e.challenge);
+                return await this.verifyEmailCode({ emailCode, jwt: e.challenge.jwt, locale: params.locale });
+            }
+            throw e;
+        }
+    }
+
+    private parseResponse<T>(
+        bytes: Uint8Array,
+        extract: (f: ProtoField) => T | undefined,
+        expected: string,
+    ): T {
+        for (const f of decodeMessage(bytes)) {
+            const value = extract(f);
+            if (value !== undefined) return value;
+            if (f.field === 6 && f.value instanceof Uint8Array) {
+                throw new TinderEmailRequiredError(parseEmailRequired(f.value));
+            }
+            if (f.field === 16 && f.value instanceof Uint8Array) {
+                throw new TinderCaptchaRequiredError(parseCaptchaChallenge(f.value));
+            }
+        }
+        throw new TinderLoginError(`Unexpected AuthGatewayResponse: missing ${expected} field`);
+    }
+
+    private async send(body: Uint8Array, locale: Locale | undefined): Promise<Uint8Array> {
+        const url = new URL(AUTH_LOGIN_ENDPOINT);
+        url.searchParams.set('locale', locale ?? DEFAULT_LOCALE);
+
+        const elapsed = String(Date.now() - this.startedAt);
+        const headers: Record<string, string> = {
+            ...MOBILE_HEADERS,
+            'app-session-id': this.appSessionId,
+            'app-session-time-elapsed': elapsed,
+            'user-session-id': 'null',
+            'user-session-time-elapsed': elapsed,
+            'persistent-device-id': this.persistentDeviceId,
+            'funnel-session-id': this.funnelSessionId,
+        };
+
+        const response = await fetch(url.toString(), { method: 'POST', headers, body: body as BodyInit });
+        if (!response.ok) {
+            const text = await response.text().catch(() => '');
+            throw new TinderLoginError(
+                `Tinder auth login failed: HTTP ${response.status} ${text}`,
+                response.status,
+                text,
+            );
+        }
+        return new Uint8Array(await response.arrayBuffer());
+    }
+}
+
+function parseSmsSent(bytes: Uint8Array): SmsSentResponse {
+    let phone = '';
+    let otpLength = 0;
+    let deliveryMethod = 0;
+    for (const f of decodeMessage(bytes)) {
+        if (f.field === 2 && f.value instanceof Uint8Array) {
+            phone = decodeString(f.value);
+        } else if (f.field === 3 && f.value instanceof Uint8Array) {
+            otpLength = firstVarint(decodeMessage(f.value), 1) ?? 0;
+        } else if (f.field === 4 && f.value instanceof Uint8Array) {
+            deliveryMethod = firstVarint(decodeMessage(f.value), 1) ?? 0;
+        }
+    }
+    return { phone, otpLength, deliveryMethod };
+}
+
+function parseAuthSuccess(bytes: Uint8Array): LoginSuccessResponse {
+    let refreshToken = '';
+    let apiToken = '';
+    let userId = '';
+    let createdAt = 0;
+    for (const f of decodeMessage(bytes)) {
+        if (!(f.value instanceof Uint8Array)) continue;
+        if (f.field === 1) refreshToken = decodeString(f.value);
+        else if (f.field === 2) apiToken = decodeString(f.value);
+        else if (f.field === 4) userId = decodeString(f.value);
+        else if (f.field === 5) createdAt = firstVarint(decodeMessage(f.value), 1) ?? 0;
+    }
+    return { apiToken, refreshToken, userId, createdAt };
+}
+
+function parseEmailRequired(bytes: Uint8Array): EmailRequiredChallenge {
+    let jwt = '';
+    let emailMasked = '';
+    let otpLength = 0;
+    for (const f of decodeMessage(bytes)) {
+        if (!(f.value instanceof Uint8Array)) continue;
+        if (f.field === 1) {
+            for (const inner of decodeMessage(f.value)) {
+                if (inner.field === 1 && inner.value instanceof Uint8Array) jwt = decodeString(inner.value);
+            }
+        } else if (f.field === 3) {
+            emailMasked = decodeString(f.value);
+        } else if (f.field === 4) {
+            otpLength = firstVarint(decodeMessage(f.value), 1) ?? 0;
+        }
+    }
+    return { jwt, emailMasked, otpLength };
+}
+
+function parseCaptchaChallenge(bytes: Uint8Array): CaptchaChallenge {
+    let jwt = '';
+    let publicKey = '';
+    let blob = '';
+    for (const f of decodeMessage(bytes)) {
+        if (!(f.value instanceof Uint8Array)) continue;
+        if (f.field === 1) jwt = decodeString(f.value);
+        else if (f.field === 2) publicKey = decodeString(f.value);
+        else if (f.field === 3) blob = decodeString(f.value);
+    }
+    return { jwt, publicKey, blob };
+}
+
+function firstVarint(fields: ProtoField[], field: number): number | undefined {
+    for (const f of fields) {
+        if (f.field === field && f.wireType === 0 && typeof f.value === 'number') return f.value;
+    }
+    return undefined;
+}

--- a/src/interfaces/auth.ts
+++ b/src/interfaces/auth.ts
@@ -1,0 +1,24 @@
+export interface SmsSentResponse {
+    phone: string;
+    otpLength: number;
+    deliveryMethod: number;
+}
+
+export interface LoginSuccessResponse {
+    apiToken: string;
+    refreshToken: string;
+    userId: string;
+    createdAt: number;
+}
+
+export interface CaptchaChallenge {
+    jwt: string;
+    publicKey: string;
+    blob: string;
+}
+
+export interface EmailRequiredChallenge {
+    jwt: string;
+    emailMasked: string;
+    otpLength: number;
+}

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -4,3 +4,4 @@ export * from './like.ts';
 export * from './dislike.ts';
 export * from './profile.ts';
 export * from './location.ts';
+export * from './auth.ts';

--- a/src/protobuf.ts
+++ b/src/protobuf.ts
@@ -1,0 +1,79 @@
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+export function encodeVarint(value: number): number[] {
+    const out: number[] = [];
+    let v = value >>> 0;
+    while (v >= 0x80) {
+        out.push((v & 0x7f) | 0x80);
+        v >>>= 7;
+    }
+    out.push(v & 0x7f);
+    return out;
+}
+
+export function encodeString(field: number, value: string): number[] {
+    const bytes = textEncoder.encode(value);
+    return [
+        ...encodeVarint((field << 3) | 2),
+        ...encodeVarint(bytes.length),
+        ...bytes,
+    ];
+}
+
+export function encodeMessage(field: number, body: ArrayLike<number>): number[] {
+    const arr = Array.from(body);
+    return [
+        ...encodeVarint((field << 3) | 2),
+        ...encodeVarint(arr.length),
+        ...arr,
+    ];
+}
+
+export interface ProtoField {
+    field: number;
+    wireType: 0 | 2;
+    value: number | Uint8Array;
+}
+
+export function decodeMessage(bytes: Uint8Array): ProtoField[] {
+    const fields: ProtoField[] = [];
+    let offset = 0;
+    while (offset < bytes.length) {
+        const tag = readVarint(bytes, offset);
+        offset = tag.offset;
+        const field = tag.value >>> 3;
+        const wireType = tag.value & 7;
+        if (wireType === 0) {
+            const v = readVarint(bytes, offset);
+            offset = v.offset;
+            fields.push({ field, wireType: 0, value: v.value });
+        } else if (wireType === 2) {
+            const len = readVarint(bytes, offset);
+            offset = len.offset;
+            const value = bytes.subarray(offset, offset + len.value);
+            offset += len.value;
+            fields.push({ field, wireType: 2, value });
+        } else {
+            throw new Error(`Unsupported protobuf wire type: ${wireType}`);
+        }
+    }
+    return fields;
+}
+
+export function decodeString(bytes: Uint8Array): string {
+    return textDecoder.decode(bytes);
+}
+
+function readVarint(bytes: Uint8Array, offset: number): { value: number; offset: number } {
+    let value = 0;
+    let shift = 0;
+    while (true) {
+        if (offset >= bytes.length) throw new Error('Unexpected end of varint');
+        const byte = bytes[offset++];
+        value |= (byte & 0x7f) << shift;
+        if ((byte & 0x80) === 0) return { value: value >>> 0, offset };
+        shift += 7;
+        if (shift > 35) throw new Error('Varint too long');
+    }
+}


### PR DESCRIPTION
Closes #2

## Summary

  Adds a programmatic login flow so consumers no longer need to extract `X-AUTH-TOKEN` manually from Tinder Web's IndexedDB. The new `LoginSession` class drives Tinder's protobuf auth endpoint (`POST
  /v3/auth/login`) using mobile iOS headers, which avoid the Arkose Labs CAPTCHA challenge the web flow triggers.

  The implementation supports the full multi-factor scenario observed in production:

  1. `requestSmsCode({ phoneNumber })` → Tinder sends an SMS code.
  2. `verifySmsCode({ phoneNumber, otpCode })` → either succeeds outright **or** throws `TinderEmailRequiredError` carrying the JWT + masked email + expected OTP length.
  3. `verifyEmailCode({ emailCode, jwt })` → completes the flow and returns the `apiToken`.

  For automation, `LoginSession.login(...)` orchestrates the 3 steps via `getSmsCode` and optional `getEmailCode` callbacks (sync or async). Each callback receives the relevant Tinder response so the consumer
  can plug in any source (webhook, IMAP polling, UI prompt, etc.).

  ## Changes

  - `src/protobuf.ts` (new) — minimal hand-rolled protobuf wire-format helpers (varints, length-delimited messages). No new runtime dependencies.
  - `src/auth.ts` (new) — `LoginSession` class plus `TinderCaptchaRequiredError`, `TinderEmailRequiredError`, `TinderLoginError`.
  - `src/interfaces/auth.ts` (new) — public types: `SmsSentResponse`, `LoginSuccessResponse`, `CaptchaChallenge`, `EmailRequiredChallenge`.
  - `src/interfaces/index.ts` — re-export `./auth.ts`.
  - `index.ts` — re-export `LoginSession`, error classes, and callback types.
  - `test-login.ts` (new) — interactive end-to-end harness using `prompt()` to demonstrate the orchestrated `login` flow.
  - `README.md` — documented the new login flow, plus added a missing `superLike` usage example and API entry.

  ## How it works

  - `tinder.services.authgateway.AuthGatewayRequest` / `AuthGatewayResponse` was reverse-engineered byte-by-byte from observed traffic and validated against the `x-protobuf-message` header Tinder returns.
  - Session-related headers (`app-session-id`, `funnel-session-id`, `persistent-device-id`, `app-session-time-elapsed`, `user-session-time-elapsed`) are generated once per `LoginSession` and reused across the
  3 calls — required by Tinder's MFA pipeline; auto-generating new UUIDs per call breaks the email step.
  - `User-Agent: Tinder/15.13.0 (iPhone; iOS 17.5; Scale/3.00)` + `platform: ios` is what enables bypassing the web's Arkose challenge. If Tinder ever requires the captcha on iOS too, the library throws
  `TinderCaptchaRequiredError` with the `publicKey` + `arkoseBlob` so consumers can integrate a solver.

  ## Test plan

  - [x] `deno check src/auth.ts src/protobuf.ts index.ts test.ts test-login.ts` passes.
  - [x] Encoder verification (matches bytes captured from real traffic):
      - `encodeMessage(1, encodeString(1, '34601381673'))` → `0a 0d 0a 0b 33 34 36 30 31 33 38 31 36 37 33` ✓
      - `verifyEmailCode` body → `2a 5c 12 06 <code> 1a 52 0a 50 <jwt>` ✓
  - [x] End-to-end with real phone: `requestSmsCode` → SMS received → `verifySmsCode` throws `TinderEmailRequiredError` → `verifyEmailCode` returns `apiToken` → `TinderAPI` instance with that token
  successfully calls `api.search()`.

  ## Notes / Follow-ups

  - CAPTCHA is **not** implemented (Arkose FunCaptcha would require a solver service or browser automation). The error is exposed for consumers who want to integrate one.
  - `persistent-device-id` should be persisted between runs by the consumer; the library auto-generates one if missing, but a fresh device ID can trigger captcha — documented in README.